### PR TITLE
jeudi débug

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -293,7 +293,7 @@ class Need < ApplicationRecord
         INNER JOIN "facilities" ON "facilities"."id" = "diagnoses"."facility_id"
         INNER JOIN "solicitations" ON "solicitations"."id" = "diagnoses"."solicitation_id"
       ')
-      .where(solicitations: { email: emails })
+      .where(solicitations: { email: emails.compact })
       .or(Need.diagnosis_completed.where(diagnosis: { facilities: { siret: sirets.compact } }))
   end
 

--- a/app/services/stats/companies/by_employees.rb
+++ b/app/services/stats/companies/by_employees.rb
@@ -47,6 +47,7 @@ module Stats::Companies
     def merge_categories(results)
       merged_categories = {}
       results.each do |key, value|
+        key = nil if key == ""
         new_code = I18n.t(key, scope: 'code_to_range', default: I18n.t('00', scope: 'code_to_range')).to_s
         merged_categories[new_code] ||= {}
         merged_categories[new_code].merge!(value) { |_, o, n| o + n }


### PR DESCRIPTION
- fix rapide pour le graph des entreprises par nombre d'employés qui ne s'affiche plus. L'entreprise 93192 à un code effectif égale à `""`  (https://conseillers-entreprises-org.sentry.io/issues/5643769541/?project=5747178&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=0)
- ne pas prendre les besoins d'entreprises anonymisé dans l'historique. closes #3547