### PR TITLE
Fix Solicitation qui reviennent à l'étape contact

### DIFF
--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -41,7 +41,7 @@ module DiagnosisCreation
         end
       end
 
-      params[:step] = :contact
+      params[:step] = :contact unless diagnosis.persisted?
       params[:content] = get_solicitation_description(params)
       diagnosis.attributes = params
       diagnosis.save

--- a/spec/models/concerns/diagnosis_creation_spec.rb
+++ b/spec/models/concerns/diagnosis_creation_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe DiagnosisCreation do
     context 'with existing diagnosis' do
       subject(:create_or_update_diagnosis) { described_class.create_or_update_diagnosis(params, diagnosis) }
 
-      let(:diagnosis) { create :diagnosis }
+      let(:diagnosis) { create :diagnosis, step: :needs }
       let(:advisor) { create :user }
       let(:params) { { advisor: advisor, facility_attributes: facility_params } }
 
@@ -99,6 +99,10 @@ RSpec.describe DiagnosisCreation do
 
           it 'fetches info for ApiEntreprise and creates the diagnosis' do
             expect(create_or_update_diagnosis).to be_valid
+          end
+
+          it 'doesnt change diagnosis step' do
+            expect { create_or_update_diagnosis }.not_to change(diagnosis, :step)
           end
         end
 


### PR DESCRIPTION
Debug de : les sollicitations mauvaises qualités reviennent chez nous avec une analyse à l'étape ``contact`