### PR TITLE
Corrige les filtres des stats équipe

### DIFF
--- a/app/controllers/concerns/load_filter_options.rb
+++ b/app/controllers/concerns/load_filter_options.rb
@@ -4,7 +4,7 @@ module LoadFilterOptions
   def load_filter_options
     response = {
       antennes: @institution_antennes,
-      themes: @themes.select(:id, :label).uniq,
+      themes: @themes,
       subjects: @subjects.select(:id, :label)
     }
 
@@ -23,11 +23,11 @@ module LoadFilterOptions
     if params[:institution].present?
       institution = Institution.find(params[:institution])
       @institution_antennes = build_institution_antennes_collection(institution)
-      @themes = @themes.merge(institution.themes.order(:label))
+      @themes = @themes.merge(institution.themes).select(:id, :label).order(:label).uniq
       @subjects = @subjects.merge(institution.subjects.not_archived.order(:label))
     end
     # on verifie que le theme précédemment sélectionné fait bien partie des thèmes de l'institution
-    if params[:theme].present? && @themes.pluck(:id).include?(params[:theme].to_i)
+    if params[:theme].present? && @themes.map(&:id).include?(params[:theme].to_i)
       @subjects = @subjects.where(theme_id: params[:theme])
     end
   end

--- a/app/views/stats/team/_stats_params.haml
+++ b/app/views/stats/team/_stats_params.haml
@@ -1,4 +1,4 @@
-= form_with url: request.url, method: :get, skip_enforcing_utf8: true, local: true do |f|
+= form_with url: request.url, method: :get, skip_enforcing_utf8: true, local: true, data: { turbo: false } do |f|
   .fr-grid-row.fr-py-3w.fr-mb-3w.white-bg#stats-params{ data: { controller: 'stats', url: load_filter_options_team_index_path } }
 
     .fr-col-12.fr-col-md-4.fr-p-2w
@@ -70,4 +70,4 @@
         = f.submit t('stats.stats_params.filter'), class: 'fr-btn'
         -# Affiche le bouton s'il y a plus de filtres que les dates début et fin qui sont présentes dès le début
         - if stats.keys.count > 2
-          = link_to t('clear_search'), request.fullpath.split('?').first, class: 'fr-btn fr-btn--tertiary-no-outline'
+          = link_to t('clear_search'), request.fullpath.split('?').first, class: 'fr-btn fr-btn--tertiary-no-outline', data: { turbo: false }


### PR DESCRIPTION
closes #3663 

Pour reproduire le bug il faut aller dans les stats équipe, sélectionner une institution et filtrer. Une fois la page recharger dans le select des thèmes il y avait plusieurs lignes pour un même theme