### PR TITLE
Tâche de rattrapage de l'API RNE

### DIFF
--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -52,5 +52,8 @@ module Clockwork
     every(1.day, 'reminders_registers', :at => ['01:00', '13:00'], tz: 'UTC') do
       Admin::CreateRemindersRegistersJob.perform_later
     end
+    every(1.day, 'rattrapage_api_rne', :at => ['02:30', '12:30'], tz: 'UTC') do
+      `rake rattrapage_api_rne`
+    end
   end
 end

--- a/doc/05-gotchas.md
+++ b/doc/05-gotchas.md
@@ -7,7 +7,7 @@
 * ➡ [Gotchas & tips (fr)](05-gotchas.md)
 * [Maintenance (fr)](06-maintenance.md)
 
-# onseillers-Entreprises - Gotchas & Tips
+# Conseillers-Entreprises - Gotchas & Tips
 
 ## Problème de génération des reports
 
@@ -33,3 +33,14 @@ blobs.first.attachments.destroy_all
 ```
 
 Puis relancer la génération des rapports.
+
+## Limitations RNE
+
+Pour rappel, les limitations de l'API RNE : 
+
+- Un blocage du compte lors de 5 tentatives avec un mauvais de mot de passe (c’est ce point qui vous a bloqué)
+- Une limitation à un quota de 10 000 appels/jour, en cas de dépassement vous recevez une erreur indiquant le dépassement, mais vous pouvez vous reconnecter le lendemain
+- Une limitation système sur l’IP qui limite à 180 appels par minute par IP et qui bannit 10 minutes
+- Une limitation sur le nombre d’authentification à 5 authentification toutes les 30 secondes et qui bannit 10 minutes
+
+Parfois, l'API RNE rejette sans motif apparent nos identifiants. Il faut alors les renouveler sur   https://procedures.inpi.fr 

--- a/lib/tasks/rattrapage_api_rne.rake
+++ b/lib/tasks/rattrapage_api_rne.rake
@@ -9,7 +9,6 @@ namespace :rattrapage_api_rne do
     puts "Entreprise sans nature activite des #{@days_count} derniers jours : #{companies_to_update.count}"
     facilities_to_update.find_each do |facility|
       UseCases::SearchFacility.with_siret_and_save(facility.siret)
-      total += 1 if facility.nature_activites.any?
     end
     puts "Etablissements restant sans nature activite : #{no_nature_activite_facilities.count}"
     puts "Entreprises restant sans nature activite : #{no_nature_activite_companies.count}"

--- a/lib/tasks/rattrapage_api_rne.rake
+++ b/lib/tasks/rattrapage_api_rne.rake
@@ -1,0 +1,42 @@
+namespace :rattrapage_api_rne do
+  desc 'relaunch diagnosis if missed'
+  task relaunch_search_facility: :environment do
+    set_params
+    puts '## Relance des analyses des sollicitations'
+    facilities_to_update = no_nature_activite_facilities
+    companies_to_update = no_nature_activite_companies
+    puts "Etablissement sans nature activite des #{@days_count} derniers jours : #{facilities_to_update.count}"
+    puts "Entreprise sans nature activite des #{@days_count} derniers jours : #{companies_to_update.count}"
+    facilities_to_update.find_each do |facility|
+      UseCases::SearchFacility.with_siret_and_save(facility.siret)
+      total += 1 if facility.nature_activites.any?
+    end
+    puts "Etablissements restant sans nature activite : #{no_nature_activite_facilities.count}"
+    puts "Entreprises restant sans nature activite : #{no_nature_activite_companies.count}"
+  end
+
+  task all: %i[relaunch_search_facility]
+end
+
+desc 'Rattrapage analyse'
+task rattrapage_api_rne: %w[rattrapage_api_rne:all]
+
+def set_params
+  @days_count = 2
+  @start_at = @days_count.days.ago
+  @end_at = Time.zone.now
+end
+
+def no_nature_activite_companies
+  Company
+    .where(created_at: @start_at..@end_at)
+    .where.not(siren: nil)
+    .where(forme_exercice: nil)
+end
+
+def no_nature_activite_facilities
+  Facility
+    .where(created_at: @start_at..@end_at)
+    .where.not(siret: nil)
+    .where(nature_activites: [])
+end


### PR DESCRIPTION
close #3670

Soupçon que les erreurs RNE relatives au port 443 soient liées au dépassement involontaire de leurs limitations (par exemple : Une limitation sur le nombre d’authentification à 5 authentification toutes les 30 secondes et qui bannit 10 minutes)

-> Avoir un compte RNE technique juste pour le dev ?