### PR TITLE
Ne permet que des chiffres pour le champ téléphone

### DIFF
--- a/app/views/solicitations/step_contact.html.haml
+++ b/app/views/solicitations/step_contact.html.haml
@@ -43,7 +43,7 @@
                 class: 'fr-input white-bg',
                 autocomplete: Solicitation::AUTOCOMPLETE_TYPES[field],
                 minlength: (field == :phone_number ? '10' : nil),
-                pattern: (field == :phone_number ? '\+?[0-9]+' : nil),
+                pattern: (field == :phone_number ? '\+?[0-9\s]+' : nil),
                 value: (f.object.send(field) || params[field])
 
           - if @solicitation.errors.present?

--- a/app/views/solicitations/step_contact.html.haml
+++ b/app/views/solicitations/step_contact.html.haml
@@ -43,6 +43,7 @@
                 class: 'fr-input white-bg',
                 autocomplete: Solicitation::AUTOCOMPLETE_TYPES[field],
                 minlength: (field == :phone_number ? '10' : nil),
+                pattern: (field == :phone_number ? '\+?[0-9]+' : nil),
                 value: (f.object.send(field) || params[field])
 
           - if @solicitation.errors.present?


### PR DESCRIPTION
En fait le champs de type `tel` affiche juste un clavier dans certains cas, surtout quand on est sur mobile

closes #3674 