### PR TITLE
Modifie l'ordre des besoin dans la boite de récéption d'une équipe depuis le panier qualité

### DIFF
--- a/app/controllers/reminders/experts_controller.rb
+++ b/app/controllers/reminders/experts_controller.rb
@@ -35,7 +35,7 @@ module Reminders
     end
 
     def quo_active
-      retrieve_needs(@expert, :quo_active, view: :quo)
+      retrieve_needs(@expert, :quo_active, view: :quo, order: :asc)
     end
 
     def taking_care

--- a/spec/system/users/passwords_controller_spec.rb
+++ b/spec/system/users/passwords_controller_spec.rb
@@ -38,7 +38,7 @@ describe 'passwords', :js do
       within '.new_user' do
         click_on 'Accès conseillers', class: 'fr-btn'
       end
-      expect(page.html).to include 'Besoins reçus'
+      expect(page).to have_content 'Besoins reçus'
     end
   end
 end


### PR DESCRIPTION
- Essaie pour fixer un flaky test. Attendre que la page soit chargé avant de regarder si "Besoins reçus" apparait