### PR TITLE
Revert "Change le bouton des relances par un formulaire sans Turbo"

### DIFF
--- a/app/helpers/reminders_helper.rb
+++ b/app/helpers/reminders_helper.rb
@@ -40,11 +40,9 @@ module RemindersHelper
   end
 
   def action_button(action, need)
-    form_with model: need, url: reminders_actions_path, method: :post, data: { turbo: false } do |f|
-      f.hidden_field(:need_id, value: need.id) +
-        f.hidden_field(:category, value: action) +
-        f.submit(t(action, scope: 'reminders.needs.scopes.mark_done'), class: 'fr-btn btn-green')
-    end
+    button_to t(action, scope: 'reminders.needs.scopes.mark_done'), reminders_actions_path,
+              { params: { need_id: need.id, category: action },
+                method: :post, class: 'fr-btn btn-green', data: { turbo: false } }
   end
 
   # Todo : probable possibilité de factoriser aussi ici


### PR DESCRIPTION
Pour une raison obscure on ne peut plus cliquer sur les boutons en prod

Reverts betagouv/conseillers-entreprises#3707