### PR TITLE
Debug 241128

### DIFF
--- a/app/services/api/recherche_entreprises/search/base.rb
+++ b/app/services/api/recherche_entreprises/search/base.rb
@@ -5,6 +5,7 @@ module Api::RechercheEntreprises::Search
   end
 
   class Request < Api::RechercheEntreprises::Request
+    CLIENT_HTTP_ERRORS = [401, 403]
     private
 
     def url_key

--- a/app/services/api/recherche_entreprises/search/base.rb
+++ b/app/services/api/recherche_entreprises/search/base.rb
@@ -6,6 +6,7 @@ module Api::RechercheEntreprises::Search
 
   class Request < Api::RechercheEntreprises::Request
     CLIENT_HTTP_ERRORS = [401, 403]
+
     private
 
     def url_key

--- a/app/services/diagnosis_creation/create_automatic_diagnosis.rb
+++ b/app/services/diagnosis_creation/create_automatic_diagnosis.rb
@@ -25,7 +25,7 @@ module DiagnosisCreation
         DiagnosisCreation::Steps.new(diagnosis).autofill_steps
 
         preparation_errors = diagnosis.errors.presence || creation_result[:errors].presence
-        has_major_error = diagnosis.errors.present? || creation_result.dig(:errors, :major_api_error).present?
+        has_major_error = diagnosis.errors.present? || creation_result.dig(:errors, :major_api_error).present? || creation_result.dig(:errors, :basic_errors).present?
         if has_major_error
           diagnosis = nil
           solicitation.diagnosis.destroy if solicitation&.diagnosis&.persisted?

--- a/spec/services/diagnosis_creation/create_automatic_diagnosis_spec.rb
+++ b/spec/services/diagnosis_creation/create_automatic_diagnosis_spec.rb
@@ -78,7 +78,7 @@ describe DiagnosisCreation::CreateAutomaticDiagnosis do
         let(:prepare_needs) { [] }
 
         it do
-          expect(solicitation.diagnosis).not_to be_nil
+          expect(solicitation.diagnosis).to be_nil
           expect(solicitation.prepare_diagnosis_errors).to eq({ "basic_errors" => "Caramba !" })
         end
       end


### PR DESCRIPTION
1/ Dans API Rech entreprise, j'ai enlevé des codes d'erreur critique le 400, qui est un code bien géré chez eux avec un retour légitime. Ca nous évitera d'être spammé sur sentry pour cette fausse erreur

2/ On avait dans certains cas des erreurs dans la creation d'analyse qui étaient mal gérés. Par exemple, en cas de siret foireux -> ce n'est pas une erreur d'API, ce n'est pas une erreur dans l'objet analyse, mais une BasicError... Donc ça n'entraînait pas un rollback. J'ai remédié à ça, car alors la machine essayait de sauver une solicitation avec une analyse non persistée. Foireux.