### PR TITLE
Fix pb dans les paniers risques d'échec

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -413,7 +413,9 @@ class Need < ApplicationRecord
   def update_status
     self.matches.reload # Make sure the matches are fresh from DB; see #1421
     new_status = computed_status
-    self.update(status: new_status)
+    # skip validation car l'ajout d'une question rend invalide le besoin après coup
+    self.update_attribute(:status, new_status)
+    self.diagnosis.touch
   end
 
   def display_time

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -38,10 +38,13 @@ RSpec.describe Need do
   end
 
   describe 'update_status' do
-    context 'after match changes' do
+    context 'invalid need - after match changes' do
       let(:need) { create :need_with_matches }
 
-      before { need.matches.first.update(status: :taking_care) }
+      before do
+        allow(need).to receive(:valid?).and_return(false)
+        need.matches.first.update(status: :taking_care)
+      end
 
       subject { need.reload.status }
 


### PR DESCRIPTION
L'ajout d'une question pour le sujet "Investissement" a rendu les besoins "investissement" en cours invalides, et empêchait donc le fonctionnement du callback `update_status`.

Le plus simple m'a semblé être de skipper la validation, mais il y a peut-être un loup que je n'ai pas levé ?

close #3850 