### PR TITLE
Fix Intitulé effectif quand code_effectif vide

### DIFF
--- a/app/services/effectif/code_effectif.rb
+++ b/app/services/effectif/code_effectif.rb
@@ -25,14 +25,12 @@ module Effectif
     end
 
     def intitule_effectif
-      if @code.blank?
-        I18n.t(:missing, scope: 'codes_effectif')
-      end
-
+      return I18n.t('other') if @code.blank?
       I18n.t(@code, scope: 'codes_effectif', default: I18n.t('other'))
     end
 
     def simple_effectif
+      return I18n.t('other') if @code.blank?
       I18n.t(@code, scope: 'simple_effectif', default: I18n.t('other'))
     end
 

--- a/spec/services/effectif/code_effectif_spec.rb
+++ b/spec/services/effectif/code_effectif_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Effectif::CodeEffectif, type: :model do
       it{ is_expected.to eq 'Autre' }
     end
 
+    context 'empty string code' do
+      let(:code) { "" }
+
+      it{ is_expected.to eq 'Autre' }
+    end
+
     context 'invalid code' do
       let(:code) { 'Invalid' }
 


### PR DESCRIPTION
Suite à un problème dans la génération des fichiers des MERs mensualisés