### PR TITLE
Fix active link not highlighted in reminders sections

### DIFF
--- a/app/controllers/reminders/experts_controller.rb
+++ b/app/controllers/reminders/experts_controller.rb
@@ -7,7 +7,7 @@ module Reminders
     before_action :persist_search_params, only: [:quo_active, :taking_care, :done, :not_for_me, :expired]
 
     def index
-      redirect_to action: :many_pending_needs
+      redirect_to action: :inputs
     end
 
     def many_pending_needs

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -85,7 +85,7 @@
               = active_link_to reminders_needs_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do
                 %span.ri-feedback-line.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('reminders.needs.navbar.title')
-              = active_link_to inputs_reminders_experts_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do
+              = active_link_to reminders_experts_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do
                 %span.ri-award-fill.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('reminders.experts.navbar.title')
               = active_link_to conseiller_suivi_qualite_index_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do


### PR DESCRIPTION
| Avant | Après |
|-|-|
| <img width="791" height="372" alt="Capture d’écran 2025-08-11 à 17 00 02" src="https://github.com/user-attachments/assets/61656369-43b3-4f70-854a-a48640bc0eb2" /> | <img width="791" height="372" alt="Capture d’écran 2025-08-11 à 16 58 47" src="https://github.com/user-attachments/assets/dfb46602-bc96-4fb3-a93a-32a17b0740a3" /> |

Seul le panier “Entrées” affichait bien l’onglet “Paniers Qualité” comme activé. C’est parce que le `active_link_to` dans la navbar pointait sur `/relances/experts/arrivees`, et donc les autres paths (comme `/relances/experts/superieur-a-cinq-besoins`) ne correspondait pas au critère “actif”. 

Le fix consiste à utiliser `/relances/experts` comme lien dans la navbar, et à rediriger ce path vers `/relances/experts/arrivees`; auparavant, il redirigait vers `/relances/experts/superieur-a-cinq-besoins`. A priori, on n’utilisait `inputs_reminders_experts_path` nulle part ailleurs de critique, ce n’est donc pas un problème.