### PR TITLE
Use explicit permissions of the update-dependencies workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 1 * *'
 jobs:
   updates:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
fixes https://github.com/betagouv/conseillers-entreprises/security/code-scanning/10, I guess?