### PR TITLE
Filtrer les emails à ne pas envoyer avec before_deliver

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -7,115 +7,103 @@ class ExpertMailer < ApplicationMailer
 
   layout 'expert_mailers'
 
-  def notify_company_needs
-    with_expert_init do
-      @need = params[:need]
-      @diagnosis = @need.diagnosis
-      @solicitation = @need.solicitation
+  before_action :set_expert_params
+  before_deliver :filter_deleted_experts
 
-      mail(
-        to: @expert.email_with_display_name,
-        subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name)
-      )
-    end
+  def set_expert_params
+    @expert = params[:expert]
+    throw :abort if @expert.nil?
+
+    @support_user = @expert.support_user
+    @institution_logo_name = @expert.institution.logo&.filename
+  end
+
+  def filter_deleted_experts
+    throw :abort if @expert.deleted?
+  end
+
+  def notify_company_needs
+    @need = params[:need]
+    @diagnosis = @need.diagnosis
+    @solicitation = @need.solicitation
+
+    mail(
+      to: @expert.email_with_display_name,
+      subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name)
+    )
   end
 
   def first_notification_help
     # Email du premier besoin reçu
-    with_expert_init do
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.first_notification_help.subject')
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.first_notification_help.subject')
+    )
   end
 
   def remind_involvement
-    with_expert_init do
-      # On ne relance pas les MER les + recentes
-      inbox_needs = @expert.needs_quo_active
-      @displayed_needs = inbox_needs.matches_sent_at(Range.new(nil, 4.days.ago)).first(7)
-      return if @displayed_needs.empty?
-      @others_needs_quo_count = (inbox_needs - @displayed_needs).count
+    # On ne relance pas les MER les + recentes
+    inbox_needs = @expert.needs_quo_active
+    @displayed_needs = inbox_needs.matches_sent_at(Range.new(nil, 4.days.ago)).first(7)
+    return if @displayed_needs.empty?
+    @others_needs_quo_count = (inbox_needs - @displayed_needs).count
 
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.remind_involvement.subject')
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.remind_involvement.subject')
+    )
   end
 
   def positioning_rate_reminders
     # Envoyé depuis les paniers qualité
-    with_expert_init do
-
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.positioning_rate_reminders.subject')
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.positioning_rate_reminders.subject')
+    )
   end
 
   def re_engagement
     # Email pour ceux n'ont pas reçu de besoin depuis un moment
-    with_expert_init do
-      @need = params[:need]
+    @need = params[:need]
 
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.re_engagement.subject')
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.re_engagement.subject')
+    )
   end
 
   def closing_good_practice
     # Envoyé depuis veille - stock en cours
-    with_expert_init do
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.closing_good_practice.subject')
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.closing_good_practice.subject')
+    )
   end
 
   def last_chance
-    with_expert_init do
-      @need = params[:need]
-      @match = @expert.received_matches.find_by(need: @need)
+    @need = params[:need]
+    @match = @expert.received_matches.find_by(need: @need)
 
-      mail(
-        to: @expert.email_with_display_name,
-        reply_to: @support_user.email_with_display_name,
-        subject: t('mailers.expert_mailer.last_chance.subject', company: @need.company.name)
-      )
-    end
+    mail(
+      to: @expert.email_with_display_name,
+      reply_to: @support_user.email_with_display_name,
+      subject: t('mailers.expert_mailer.last_chance.subject', company: @need.company.name)
+    )
   end
 
   def match_feedback
-    with_expert_init do
-      @feedback = params[:feedback]
-      return if @feedback.nil?
+    @feedback = params[:feedback]
+    return if @feedback.nil?
 
-      @author = @feedback.user
-      @match = @expert.received_matches.find_by(need: @feedback.need.id)
+    @author = @feedback.user
+    @match = @expert.received_matches.find_by(need: @feedback.need.id)
 
-      mail(to: @expert.email_with_display_name,
-           subject: t('mailers.expert_mailer.match_feedback.subject', company_name: @feedback.need.company))
-    end
-  end
-
-  private
-
-  def with_expert_init
-    @expert = params[:expert]
-    return if @expert.deleted?
-    @support_user = @expert.support_user
-    @institution_logo_name = @expert.institution.logo&.filename
-    yield
+    mail(to: @expert.email_with_display_name,
+         subject: t('mailers.expert_mailer.match_feedback.subject', company_name: @feedback.need.company))
   end
 end

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -58,7 +58,7 @@ describe ExpertMailer do
 
       let(:mail) { subject }
 
-      it { expect(mail).to be_nil }
+      it { expect(mail).to be false }
     end
   end
 
@@ -80,7 +80,7 @@ describe ExpertMailer do
 
       let(:mail) { subject }
 
-      it { expect(mail).to be_nil }
+      it { expect(mail).to be false }
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -24,6 +24,5 @@ describe UserMailer do
 
       it { expect(mail).to be_nil }
     end
-
   end
 end


### PR DESCRIPTION
Ça change pas grand chose, mais ça fait un poil de code en moins. Les hooks `before_deliver` et `after_deliver` ont été ajouté dans rails 7.1 pour ça.

- `throw :abort` est la façon “normale“ d’annuler [dans une callback](https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html).
-  Malheureusement, ce n’est pas le comportement dans [`AbstractController::Callbacks`](https://github.com/rails/rails/blob/b0c813bc7b61c71dd21ee3a6c6210f6d14030f71/actionpack/lib/abstract_controller/callbacks.rb#L34), le `terminator` ne `catch` pas `:abort`, mais regarde si l’action a été `performed?` (c’est ce qui permet dans un controller rails de ne pas exécuter l’action si on répond une 404 dans un before_action).
  - Or, `ActionMailer::Base` est en fait un controller, il hérite de `ActionController::Base`
- Par contre, les callbacks `before_deliver` et `after_deliver` ont le terminator par défaut, donc on peut utiliser `throw :abort` pour annuler l’envoi. Ça a même été créé pour ce genre de cas.
- Par contre `before_deliver` est appelé _après_ que le mail est créé. C’est `before_action`, `after_action`, `before_deliver`, `after_deliver`.
- Enfin, il faut changer la spec, parce que le résultat de l’action est `false`, pas `nil`, dans ce cas.