### PR TITLE
Parallelize api calls in aggregators

### DIFF
--- a/app/services/api_consumption/aggregators/company.rb
+++ b/app/services/api_consumption/aggregators/company.rb
@@ -13,8 +13,9 @@ module ApiConsumption::Aggregators
     end
 
     def item_params
-      requests.each_with_object(base_hash.with_indifferent_access) do |request, hash|
-        response = request.new(@siren).call
+      Parallel.map(requests, in_threads: requests.size) do |request|
+        request.new(@siren).call
+      end.each_with_object(base_hash.with_indifferent_access) do |response, hash|
         hash["entreprise"].deep_merge! response
       end
     end

--- a/app/services/api_consumption/aggregators/facility.rb
+++ b/app/services/api_consumption/aggregators/facility.rb
@@ -14,8 +14,9 @@ module ApiConsumption::Aggregators
     end
 
     def item_params
-      requests.each_with_object(base_hash.with_indifferent_access) do |request, hash|
-        response = request.new(@siret).call
+      Parallel.map(requests, in_threads: requests.size) do |request|
+        request.new(@siret).call
+      end.each_with_object(base_hash.with_indifferent_access) do |response, hash|
         hash["etablissement"].deep_merge! response
       end
     end


### PR DESCRIPTION
C’est assez trivial comme changement, mais ça pourrait avoir des changements subtils. 

Avant:
facility aggregators 3.516099s
company aggregators 1.777961s

Après:
facility aggregators 1.114076s
company aggregators 1.186227s
