### PR TITLE
Afficher les erreurs d’api tierce sur la page entreprise

### DIFF
--- a/app/views/companies/_company.html.haml
+++ b/app/views/companies/_company.html.haml
@@ -1,3 +1,5 @@
+= render 'errors', errors: entreprise.errors
+
 .fr-table.fr-table--multiline
   .fr-table__wrapper
     .fr-table__container

--- a/app/views/companies/_company.html.haml
+++ b/app/views/companies/_company.html.haml
@@ -1,39 +1,42 @@
-.fr-table.fr-table--bordered.fr-table--c-sm
-  %table
-    %caption= t('.information')
-    %tbody
-      %tr
-        %td= t('.denomination')
-        %td= entreprise.name
-      - if entreprise.description.present?
-        %tr
-          %td= t('.description')
-          %td= entreprise.description
-      %tr
-        %td= t('.forme_exercice')
-        %td= translated_nature_activite(entreprise.forme_exercice) || t('undefined')
-      %tr
-        %td= t('.categorie_entreprise')
-        %td= entreprise.categorie_entreprise
-      %tr
-        %td= t('.tranche_effectif_salarie_entreprise')
-        %td= [entreprise.tranche_effectif, annee_effectif(entreprise.annee_effectif) ].join(' ')
-      %tr
-        %td= t('.siren')
-        %td= entreprise.siren
-      - if entreprise.capital_social
-        %tr
-          %td= t('.capital_social')
-          %td= number_to_currency(entreprise.capital_social, unit: "€", separator: ",", delimiter: " ")
-      %tr
-        %td= t('.forme_juridique')
-        %td= entreprise.forme_juridique_libelle
-      %tr
-        %td= t('.date_creation')
-        %td= date_from_timestamp(entreprise.date_creation)
-      %tr
-        %td= t('.date_cessation')
-        %td= date_from_timestamp(entreprise.date_cessation) || '/'
-      %tr
-        %td= t('.diffusable_commercialement')
-        %td= t(entreprise.diffusable_commercialement.to_b, scope: [:boolean, :text])
+.fr-table.fr-table--multiline
+  .fr-table__wrapper
+    .fr-table__container
+      .fr-table__content
+        %table
+          %caption= t('.information')
+          %tbody
+            %tr
+              %td= t('.denomination')
+              %td= entreprise.name
+            - if entreprise.description.present?
+              %tr
+                %td= t('.description')
+                %td= entreprise.description
+            %tr
+              %td= t('.forme_exercice')
+              %td= translated_nature_activite(entreprise.forme_exercice) || t('undefined')
+            %tr
+              %td= t('.categorie_entreprise')
+              %td= entreprise.categorie_entreprise
+            %tr
+              %td= t('.tranche_effectif_salarie_entreprise')
+              %td= [entreprise.tranche_effectif, annee_effectif(entreprise.annee_effectif) ].join(' ')
+            %tr
+              %td= t('.siren')
+              %td= entreprise.siren
+            - if entreprise.capital_social
+              %tr
+                %td= t('.capital_social')
+                %td= number_to_currency(entreprise.capital_social, unit: "€", separator: ",", delimiter: " ")
+            %tr
+              %td= t('.forme_juridique')
+              %td= entreprise.forme_juridique_libelle
+            %tr
+              %td= t('.date_creation')
+              %td= date_from_timestamp(entreprise.date_creation)
+            %tr
+              %td= t('.date_cessation')
+              %td= date_from_timestamp(entreprise.date_cessation) || '/'
+            %tr
+              %td= t('.diffusable_commercialement')
+              %td= t(entreprise.diffusable_commercialement.to_b, scope: [:boolean, :text])

--- a/app/views/companies/_errors.html.haml
+++ b/app/views/companies/_errors.html.haml
@@ -1,0 +1,7 @@
+-# locals: (errors:)
+
+- if errors.present?
+  .fr-alert.fr-alert--warning.fr-alert--sm
+    %h4.fr-alert__title= t(".title")
+    - failing_apis = [] + Array(errors[:standard_api_errors]&.keys) + Array(errors[:unreachable_apis]&.keys)
+    = t(".unavailable", names: failing_apis.map{ t(_1, scope: 'api_name') }.to_sentence, count: failing_apis.count)

--- a/app/views/companies/_facility.html.haml
+++ b/app/views/companies/_facility.html.haml
@@ -1,3 +1,5 @@
+= render 'errors', errors: etablissement.errors
+
 .fr-table.fr-table--multiline
   .fr-table__wrapper
     .fr-table__container

--- a/app/views/companies/_facility.html.haml
+++ b/app/views/companies/_facility.html.haml
@@ -1,49 +1,52 @@
-.fr-table.fr-table--bordered.fr-table--c-sm
-  %table
-    %caption= caption
-    %tbody
-      %tr
-        %td= t('.siret')
-        %td= etablissement.siret
-      - if etablissement.nature_activites.any?
-        %tr
-          %td= t('.nature_activites')
-          %td
-            = translated_nature_activites(etablissement.nature_activites).join(', ')
-      %tr
-        %td= t('.naf')
-        %td #{etablissement.naf_code} - #{etablissement.naf_libelle}
-      - if etablissement.nafa_codes.any?
-        %tr
-          %td= t('.nafa')
-          %td
-            = etablissement.nafa_codes.map{ |code| [code, NafCode.nafa_libelle(code)].join(' - ') }.join(', ')
-      %tr
-        %td= t('.date_mise_a_jour')
-        %td= date_from_timestamp(etablissement.date_derniere_mise_a_jour)
-      %tr
-        %td= t('.tranche_effectif_salarie_etablissement')
-        %td= [etablissement.tranche_effectif, annee_effectif(etablissement.annee_effectif) ].join(' ')
-      %tr
-        %td= t('.date_creation_etablissement')
-        %td= date_from_timestamp(etablissement.date_creation)
-      %tr
-        - if etablissement.libelle_region.present?
-          %td= t('.region_implantation')
-          %td= etablissement.libelle_region
-      %tr
-        %td= t('.commune_implantation')
-        %td= etablissement.commune
-      %tr
-        %td= t('.idcc')
-        %td= etablissement.idcc
-      %tr
-        %td= t('.opco')
-        %td= etablissement.opco&.name
-      %tr
-        %td= t('.adresse')
-        %td
-          - adresse = etablissement.adresse["acheminement_postal"]
-          - (1..7).each do |i|
-            - if adresse["l#{i}"].present?
-              %p= adresse["l#{i}"]
+.fr-table.fr-table--multiline
+  .fr-table__wrapper
+    .fr-table__container
+      .fr-table__content
+        %table
+          %caption= caption
+          %tbody
+            %tr
+              %td= t('.siret')
+              %td= etablissement.siret
+            - if etablissement.nature_activites.any?
+              %tr
+                %td= t('.nature_activites')
+                %td
+                  = translated_nature_activites(etablissement.nature_activites).join(', ')
+            %tr
+              %td= t('.naf')
+              %td #{etablissement.naf_code} - #{etablissement.naf_libelle}
+            - if etablissement.nafa_codes.any?
+              %tr
+                %td= t('.nafa')
+                %td
+                  = etablissement.nafa_codes.map{ |code| [code, NafCode.nafa_libelle(code)].join(' - ') }.join(', ')
+            %tr
+              %td= t('.date_mise_a_jour')
+              %td= date_from_timestamp(etablissement.date_derniere_mise_a_jour)
+            %tr
+              %td= t('.tranche_effectif_salarie_etablissement')
+              %td= [etablissement.tranche_effectif, annee_effectif(etablissement.annee_effectif) ].join(' ')
+            %tr
+              %td= t('.date_creation_etablissement')
+              %td= date_from_timestamp(etablissement.date_creation)
+            %tr
+              - if etablissement.libelle_region.present?
+                %td= t('.region_implantation')
+                %td= etablissement.libelle_region
+            %tr
+              %td= t('.commune_implantation')
+              %td= etablissement.commune
+            %tr
+              %td= t('.idcc')
+              %td= etablissement.idcc
+            %tr
+              %td= t('.opco')
+              %td= etablissement.opco&.name
+            %tr
+              %td= t('.adresse')
+              %td
+                - adresse = etablissement.adresse["acheminement_postal"]
+                - (1..7).each do |i|
+                  - if adresse["l#{i}"].present?
+                    %p= adresse["l#{i}"]

--- a/app/views/companies/_mandataire.html.haml
+++ b/app/views/companies/_mandataire.html.haml
@@ -1,27 +1,30 @@
-.fr-table.fr-table--bordered.fr-table--c-sm
-  %table
-    %caption= t('.mandataires_sociaux')
-    %tbody
-      - if mandataire['type'] == 'personne_morale'
-        %tr
-          %td{ colspan: 2 }= t('.personne_morale')
-      - if mandataire['raison_sociale'].present?
-        %tr
-          %td= t('.raison_sociale')
-          %td= mandataire['raison_sociale'].humanize
-      - if mandataire['prenom'].present? && mandataire['nom'].present?
-        %tr
-          %td= t('.nom')
-          %td #{mandataire['prenom'].humanize} #{mandataire['nom'].humanize}
-      - if mandataire['fonction'].present?
-        %tr
-          %td= t('.fonction')
-          %td= mandataire['fonction'].humanize
-      - if mandataire['identifiant'].present?
-        %tr
-          %td= t('.identifiant')
-          %td= mandataire['identifiant']
-      - if mandataire['date_naissance_timestamp'].present?
-        %tr
-          %td= t('.date_naissance')
-          %td= date_from_timestamp(mandataire['date_naissance_timestamp'])
+.fr-table
+  .fr-table__wrapper
+    .fr-table__container
+      .fr-table__content
+        %table
+          %caption= t('.mandataires_sociaux')
+          %tbody
+            - if mandataire['type'] == 'personne_morale'
+              %tr
+                %td{ colspan: 2 }= t('.personne_morale')
+            - if mandataire['raison_sociale'].present?
+              %tr
+                %td= t('.raison_sociale')
+                %td= mandataire['raison_sociale'].humanize
+            - if mandataire['prenom'].present? && mandataire['nom'].present?
+              %tr
+                %td= t('.nom')
+                %td #{mandataire['prenom'].humanize} #{mandataire['nom'].humanize}
+            - if mandataire['fonction'].present?
+              %tr
+                %td= t('.fonction')
+                %td= mandataire['fonction'].humanize
+            - if mandataire['identifiant'].present?
+              %tr
+                %td= t('.identifiant')
+                %td= mandataire['identifiant']
+            - if mandataire['date_naissance_timestamp'].present?
+              %tr
+                %td= t('.date_naissance')
+                %td= date_from_timestamp(mandataire['date_naissance_timestamp'])

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -179,6 +179,11 @@ fr:
       information: Informations sur l’entreprise
       siren: SIREN
       tranche_effectif_salarie_entreprise: Tranche d’effectif de salariés de l’entreprise
+    errors:
+      title: Certaines informations ne peuvent pas être affichées en raison d’un problème d’accès aux données.
+      unavailable:
+        one: "%{names} : temporairement indisponible."
+        other: "%{names} : temporairement indisponibles."
     facility:
       adresse: Adresse
       commune_implantation: Commune d’implantation


### PR DESCRIPTION
closes #3998

J’en ai profité pour corriger l’affichage des tables qui n’était pas très content avec le DSFR.

| Avant | Après |
|-|-|
| <img width="1048" height="1137" alt="Capture d’écran 2025-09-22 à 13 15 39" src="https://github.com/user-attachments/assets/93a39219-753a-4f0f-bb87-00875a17347d" /> | <img width="1048" height="1137" alt="Capture d’écran 2025-09-22 à 13 14 48" src="https://github.com/user-attachments/assets/4e8af44d-28ea-4635-b217-de2ffbb20637" /> |

Cette PR ne fait qu’afficher les erreurs “standard_error” et “unreachable”. Je vais faire une autre issue pour un réusinage de la gestion des erreurs pour les apis. Notamment:
- Remettre à plat la distinction entre les erreurs majeurs (qui déclenchent `TechnicalError`, et qui pour l’instant sont affichées sous formes de flash) et les erreurs mineures, qui elles-mêmes sont découpées en “unreachable” et “standard”;
- Permettre de simuler les erreurs d’API pendant les tests et le développement;
- Permettre de savoir quels champs sont attendus de quelle api pour indiquer les erreurs sur les champs spécifique;
- Voir ce qui est déjà fait dans les sollicitations en particulier [autour de la méthode `prepare_diagnosis_errors_to_s`](https://github.com/betagouv/conseillers-entreprises/blob/3e912416549f22db742583096c49868642237045/app/models/solicitation.rb#L452).