### PR TITLE
Mets à jour la dénomination des stats

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -299,6 +299,5 @@ fr:
       ym: "%Y-%m"
     pm: pm
   update: Mettre à jour
-  usage_stats: Statistiques
   'yes': oui
   you_wish: 'Échanger avec un conseiller pour :'

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -1252,12 +1252,13 @@ fr:
         unselect_partner: Attention, les statistiques publiques mesurent l’activité cumulée des partenaires.
       matches: Pilotage par partenaire
       needs: Pilotage par besoins
-      public: Statistiques publiques
+      public: Statistiques générales
     with_diagnosis: Besoins transmis
     without_diagnosis: Besoins non transmis
   step_number: Étape %{actual} sur %{total}
   to_new_window: ouvre une nouvelle fenêtre
   undefined: Non défini
+  usage_stats: Statistiques publiques
   usage_team_stats: Statistiques équipe
   user_pages:
     tutoriels:


### PR DESCRIPTION
- dans le footer "Statistiques" devient "Statistiques publiques"
- dans les stats équipe, le premier onglet "Statiques publiques" devient "Statistiques générales"

closes #4014 