### PR TITLE
Fix yaml indentation for circleci jobs filters (followup #4021)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,14 +129,14 @@ workflows:
   build_and_test:
     jobs:
       - test:
-        filters:
-          branches:
-            ignore:
-              - main
-              - production
+          filters:
+            branches:
+              ignore:
+                - main
+                - production
       - lint:
-        filters:
-          branches:
-            ignore:
-              - main
-              - production
+          filters:
+            branches:
+              ignore:
+                - main
+                - production


### PR DESCRIPTION
followup #4021