### PR TITLE
Disable zip64 globally to make our Excel exports compatible with Google Sheets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'sib-api-v3-sdk', '~> 7.2'
 gem 'recipient_interceptor'
 gem 'ip_anonymizer'
 gem 'highline'
-gem 'caxlsx', '~> 3.4.1' # https://github.com/betagouv/conseillers-entreprises/issues/4003
+gem 'caxlsx'
 gem 'caxlsx_rails'
 gem 'split', require: 'split/dashboard'
 gem 'matrix'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,11 +180,11 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    caxlsx (3.4.1)
+    caxlsx (4.4.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
-      rubyzip (>= 1.3.0, < 3)
+      rubyzip (>= 2.4, < 4)
     caxlsx_rails (0.6.4)
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
@@ -620,7 +620,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubystats (0.4.1)
       matrix
-    rubyzip (2.4.1)
+    rubyzip (3.1.1)
     sass-embedded (1.91.0-arm64-darwin)
       google-protobuf (~> 4.31)
     sass-embedded (1.91.0-x86_64-linux-gnu)
@@ -771,7 +771,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
-  caxlsx (~> 3.4.1)
+  caxlsx
   caxlsx_rails
   clockwork
   css_parser

--- a/config/initializers/caxslx.rb
+++ b/config/initializers/caxslx.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Disable zip64 globally to make our Excel exports compatible with Google Sheets.
+# See https://github.com/betagouv/conseillers-entreprises/issues/4008.
+# Remove once https://github.com/caxlsx/caxlsx/pull/482 is resolved.
+Zip.write_zip64_support = false


### PR DESCRIPTION
fixes #4008 

Ça ne change pas grand chose dans les faits par rapport à #4003, mais ça nous évite de fixer une version de dépendance.

ℹ️ Surveiller les prochaines releases de caxslx, pour désactiver ce patch une fois que https://github.com/caxlsx/caxlsx/pull/482 est mergée.