### PR TITLE
Prend en compte le bon sujet pour l'email de mauvaise qualité

### DIFF
--- a/app/mailers/solicitation_mailer.rb
+++ b/app/mailers/solicitation_mailer.rb
@@ -7,7 +7,7 @@ class SolicitationMailer < ApplicationMailer
   def bad_quality(solicitation)
     @solicitation = solicitation
     @cooperation_logo_name = @solicitation.cooperation&.logo&.filename
-    @landing_subject = LandingSubject.not_archived.find_by(subject: @solicitation.final_subject)
+    @landing_subject = @solicitation.final_landing_subject
 
     mail(to: solicitation.email, subject: t('mailers.solicitation.subject'))
   end

--- a/app/mailers/solicitation_mailer.rb
+++ b/app/mailers/solicitation_mailer.rb
@@ -7,8 +7,7 @@ class SolicitationMailer < ApplicationMailer
   def bad_quality(solicitation)
     @solicitation = solicitation
     @cooperation_logo_name = @solicitation.cooperation&.logo&.filename
-    @landing_subject = LandingSubject.joins(landing_theme: :landings).find_by(subject: @solicitation.needs&.first&.subject, landings: [@solicitation.landing])
-    @landing_subject = @solicitation.landing_subject if @landing_subject.nil?
+    @landing_subject = LandingSubject.not_archived.find_by(subject: @solicitation.final_subject)
 
     mail(to: solicitation.email, subject: t('mailers.solicitation.subject'))
   end

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -611,16 +611,18 @@ class Solicitation < ApplicationRecord
   end
 
   # Il peut y avoir des sollicitations sans need, et des needs sans sollicitation
-  def final_subject
+  def final_landing_subject
     if needs.present?
-      needs.first.subject
+      subject = needs.first.subject
+      Landing.accueil&.landing_subjects&.not_archived&.find_by(subject:) ||
+        LandingSubject.not_archived.find_by(subject:)
     else
-      landing_subject.title
+      landing_subject
     end
   end
 
   def final_subject_title
-    final_subject.label
+    final_landing_subject.title
   end
 
   # Provenance

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -611,13 +611,17 @@ class Solicitation < ApplicationRecord
   end
 
   # Il peut y avoir des sollicitations sans need, et des needs sans sollicitation
-  def final_subject_title
+  def final_subject
     if needs.present?
-      needs.first.subject.label
+      needs.first.subject
     else
       landing_subject.title
     end
-end
+  end
+
+  def final_subject_title
+    final_subject.label
+  end
 
   # Provenance
   #

--- a/app/views/mailers/company_mailer/not_yet_taken_care.mjml
+++ b/app/views/mailers/company_mailer/not_yet_taken_care.mjml
@@ -4,7 +4,7 @@
 
     <mj-text><%= t('mailers.company_mailer.intro_from_solicitation_html', company: @solicitation.diagnosis.company.name) %></mj-text>
 
-    <mj-text><strong><%= @solicitation.landing_subject.title %></strong></mj-text>
+    <mj-text><strong><%= @solicitation.final_subject_title %></strong></mj-text>
 
     <mj-text><%= t('.we_continue_to_follow_up_html') %></mj-text>
 

--- a/app/views/mailers/solicitation_mailer/bad_quality.mjml
+++ b/app/views/mailers/solicitation_mailer/bad_quality.mjml
@@ -2,10 +2,10 @@
   <mj-column>
     <mj-text><%= t('mailers.hello') %></mj-text>
     <% if @solicitation.cooperation.present? %>
-      <mj-text><%= t('.intro_cooperation_html', subject: @solicitation.subject, website: @solicitation.cooperation.name) %></mj-text>
+      <mj-text><%= t('.intro_cooperation_html', subject: @solicitation.final_subject_title, website: @solicitation.cooperation.name) %></mj-text>
       <mj-text><%= t('mailers.cooperation_uses_ce') %></mj-text>
     <% else %>
-      <mj-text><%= t('.intro_html', link_to_root: link_to(t('app_name'), root_url), subject: @solicitation.subject) %></mj-text>
+      <mj-text><%= t('.intro_html', link_to_root: link_to(t('app_name'), root_url), subject: @solicitation.final_subject_title) %></mj-text>
     <% end %>
     <mj-text>
       <%= t('.for_better_taking_care_html') %>

--- a/spec/mailers/company_mailer_spec.rb
+++ b/spec/mailers/company_mailer_spec.rb
@@ -33,6 +33,41 @@ describe CompanyMailer do
     it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER.call }
   end
 
+  describe '#not_yet_taken_care' do
+    subject(:mail) { described_class.not_yet_taken_care(solicitation).deliver_now }
+
+    let!(:initial_subject) { create :subject, label: "Sujet initial" }
+    let!(:initial_landing_subject) { create :landing_subject, subject: initial_subject, title: "Sujet initial" }
+    let!(:solicitation) { create :solicitation, landing_subject: initial_landing_subject }
+    let!(:need) { create :need_with_matches, solicitation: solicitation, subject: need_subject }
+
+    context 'when need has not been requalified' do
+      let(:need_subject) { initial_subject }
+
+      it_behaves_like 'an email'
+
+      it 'uses the original subject in the body' do
+        expect(mail.body.parts.first.body).to match(/#{initial_subject.label.split.join('\s*')}/)
+      end
+    end
+
+    context 'when need has been requalified with a different subject' do
+      let(:need_subject) { create :subject, label: "Sujet requalifié" }
+
+      it_behaves_like 'an email'
+
+      it 'uses the requalified subject in the body, not the original one' do
+        expect(mail.body.parts.first.body).to match(/#{need_subject.label.split.join('\s*')}/)
+        expect(mail.body.parts.first.body).not_to include initial_landing_subject.title
+      end
+
+      it 'shows the same subject in the mail subject line and in the body' do
+        expect(mail.subject).to eq I18n.t('mailers.company_mailer.not_yet_taken_care.subject', subject: solicitation.final_subject_title)
+        expect(mail.body.parts.first.body).to match(/#{solicitation.final_subject_title.split.join('\s*')}/)
+      end
+    end
+  end
+
   describe '#intelligent_retention' do
     subject(:mail) { described_class.intelligent_retention(need, email_retention).deliver_now }
 

--- a/spec/mailers/company_mailer_spec.rb
+++ b/spec/mailers/company_mailer_spec.rb
@@ -53,11 +53,12 @@ describe CompanyMailer do
 
     context 'when need has been requalified with a different subject' do
       let(:need_subject) { create :subject, label: "Sujet requalifié" }
+      let!(:need_landing_subject) { create :landing_subject, subject: need_subject, title: "Sujet requalifié" }
 
       it_behaves_like 'an email'
 
       it 'uses the requalified subject in the body, not the original one' do
-        expect(mail.body.parts.first.body).to match(/#{need_subject.label.split.join('\s*')}/)
+        expect(mail.body.parts.first.body).to match(/#{need_landing_subject.title.split.join('\s*')}/)
         expect(mail.body.parts.first.body).not_to include initial_landing_subject.title
       end
 

--- a/spec/mailers/solicitation_mailer_spec.rb
+++ b/spec/mailers/solicitation_mailer_spec.rb
@@ -20,14 +20,14 @@ describe SolicitationMailer do
     let(:landing) { create :landing }
     let!(:initial_subject) { create :subject }
     let!(:initial_landing_theme) { create :landing_theme, landings: [landing] }
-    let!(:initial_landing_subject) { create :landing_subject, subject: initial_subject, description_explanation: "initial description", landing_theme: initial_landing_theme }
+    let!(:initial_landing_subject) { create :landing_subject, subject: initial_subject, title: "Sujet initial", description_explanation: "initial description", landing_theme: initial_landing_theme }
     let!(:solicitation) { create :solicitation, landing_subject: initial_landing_subject, landing: landing }
 
     subject(:mail) { described_class.bad_quality(solicitation).deliver_now }
 
     context 'when need has been changed' do
       let!(:second_landing_theme) { create :landing_theme, landings: [landing] }
-      let!(:second_landing_subject) { create :landing_subject, subject: second_subject, description_explanation: "second description", landing_theme: second_landing_theme }
+      let!(:second_landing_subject) { create :landing_subject, subject: second_subject, title: "Sujet requalifié", description_explanation: "second description", landing_theme: second_landing_theme }
       let!(:second_subject) { create :subject }
       let!(:need) { create :need_with_matches, solicitation: solicitation, subject: second_subject }
 
@@ -46,6 +46,21 @@ describe SolicitationMailer do
       it 'include initial subject title and description' do
         expect(mail.body.parts.first.body).to match(/#{initial_landing_subject.description_explanation.split.join('\s*')}/)
         expect(mail.body.parts.first.body).to match(/#{initial_landing_subject.title.split.join('\s*')}/)
+      end
+    end
+
+    context 'when need has been changed to a subject not offered on the original landing' do
+      let(:other_landing) { create :landing }
+      let!(:other_landing_theme) { create :landing_theme, landings: [other_landing] }
+      let!(:second_landing_subject) { create :landing_subject, subject: second_subject, title: "Sujet requalifié ailleurs", description_explanation: "instructions du sujet requalifié", landing_theme: other_landing_theme }
+      let!(:second_subject) { create :subject }
+      let!(:need) { create :need_with_matches, solicitation: solicitation, subject: second_subject }
+
+      it 'still uses the requalified subject title and description, not the initial ones' do
+        expect(mail.body.parts.first.body).not_to include initial_landing_subject.description_explanation
+        expect(mail.body.parts.first.body).not_to include initial_landing_subject.title
+        expect(mail.body.parts.first.body).to match(/#{second_landing_subject.description_explanation.split.join('\s*')}/)
+        expect(mail.body.parts.first.body).to match(/#{second_landing_subject.title.split.join('\s*')}/)
       end
     end
   end

--- a/spec/models/solicitation_spec.rb
+++ b/spec/models/solicitation_spec.rb
@@ -818,9 +818,10 @@ end
 
     context 'with needs' do
       let(:subject_2) { create :subject, label: 'Subject 2 label' }
+      let!(:landing_subject_2) { create :landing_subject, title: 'Landing Subject 2 Title', subject: subject_2 }
       let!(:need) { create :need, subject: subject_2, diagnosis: create(:diagnosis, solicitation: solicitation) }
 
-      it { is_expected.to eq 'Subject 2 label' }
+      it { is_expected.to eq 'Landing Subject 2 Title' }
     end
   end
 end


### PR DESCRIPTION
Si un chef d'entreprise dépose ça demande avec un mauvais sujet et en plus incomplete, qu'un membre de l'équipe de SPCE change le sujet et envoie un email automatique "mauvaise qualité", c'etait le sujet non modifié qui est pris en compte. Donc le chef d'entreprise se retrouve avec un mail qui demande les mauvaises informations.
closes 

Je suis tombé sur la méthode `final_subject_title` qui avait un comportement étrange de renvoyer le titre du sujet du besoin ou du landing subject. Je l'ai modifié pour renvoyer toujours le titre d'un `landing_subject` parce que c'est ce qui est affiché sur le site qui est prévu pour les entreprises, pas le label du sujet en admin. Je choisi le `landing_subject` de la landing accueil en priorité, c'est la landing du site.

#4606 