### PR TITLE
Corrige le formulaire pour les filtres des experts

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -343,8 +343,8 @@ ActiveAdmin.register Expert do
         mf.input :raw_accepted_legal_forms
         mf.input :raw_excluded_legal_forms
         mf.input :raw_accepted_naf_codes, as: :text, input_html: { rows: 5 }
-        mf.input :raw_accepted_naf_codes, as: :text, input_html: { rows: 5 }
-        mf.input :raw_accepted_naf_codes, as: :text, input_html: { rows: 5 }
+        mf.input :raw_excluded_naf_codes, as: :text, input_html: { rows: 5 }
+        mf.input :raw_excluded_insee_codes, as: :text, input_html: { rows: 5 }
       end
     end
 


### PR DESCRIPTION
il y avait 3 fois les codes NAF acceptés. Il manquait les codes NAF rejetés et les codes INSEE rejetés

closes #4637 