### PR TITLE
Paniers qualité - applique le fitre par région pour le compteur du menu

### DIFF
--- a/app/controllers/monitoring/antennes_controller.rb
+++ b/app/controllers/monitoring/antennes_controller.rb
@@ -32,9 +32,9 @@ class Monitoring::AntennesController < ApplicationController
   def collections_counts
     @collections_counts ||=
       {
-        often_not_for_me: Antenne.often_not_for_me.size,
-        rarely_done: Antenne.rarely_done.size,
-        rarely_satisfying: Antenne.rarely_satisfying.size,
+        often_not_for_me: Antenne.often_not_for_me.apply_filters(index_search_params).size,
+        rarely_done: Antenne.rarely_done.apply_filters(index_search_params).size,
+        rarely_satisfying: Antenne.rarely_satisfying.apply_filters(index_search_params).size,
       }
   end
 


### PR DESCRIPTION
Les filtres n'etaient pas appliqué dans le menu pour compter le nombre d'experts

<img width="629" height="225" alt="Screenshot 2026-08-06 at 14 10 45" src="https://github.com/user-attachments/assets/c1a9d5c7-597b-4a09-b010-4da0f5a7ac46" />

<img width="615" height="213" alt="Screenshot 2026-08-06 at 14 10 30" src="https://github.com/user-attachments/assets/89ae6345-a10a-43b1-a22a-785ddaf8efbc" />


closes #4642 