### PR TITLE
Amélioration de l’import

### DIFF
--- a/app/models/concerns/with_territorial_zones.rb
+++ b/app/models/concerns/with_territorial_zones.rb
@@ -4,7 +4,7 @@ module WithTerritorialZones
   included do
     has_many :territorial_zones, as: :zoneable, dependent: :destroy, inverse_of: :zoneable
     accepts_nested_attributes_for :territorial_zones, allow_destroy: true
-    validates_associated :territorial_zones, on: :import
+    validate :territorial_zones_codes_are_known, on: :import
 
     scope :by_region, -> (region_code) {
       return all if region_code.blank?
@@ -25,6 +25,20 @@ module WithTerritorialZones
         record.insee_codes.intersect?(insee_codes)
       end
     }
+
+    def territorial_zones_codes_are_known
+      codes_by_zone_type = territorial_zones.pluck(:zone_type, :code)
+        .group_by(&:first).transform_values{ it.map(&:last) }
+
+      codes_by_zone_type.each do |zone_type, codes|
+        known_codes = WithTerritorialZones.known_insee_codes(zone_type)
+        unknown_codes = (Set.new(codes) - known_codes)
+        if unknown_codes.present?
+          zone = I18n.t(zone_type, scope: 'activerecord.attributes.territorial_zone')
+          errors.add(:territorial_zones, :not_found, zone_type: zone, codes: unknown_codes.to_a.to_sentence)
+        end
+      end
+    end
   end
 
   def insee_codes
@@ -64,4 +78,11 @@ module WithTerritorialZones
 
     (commune_codes + territory_codes).uniq
   end
+
+  def known_insee_codes(zone_type)
+    @codes ||= {}
+    model_class = TerritorialZone::ZONE_TYPE_MODELS[zone_type]
+    @codes[model_class] ||= Set.new(model_class.all.map(&:code))
+  end
+  module_function :known_insee_codes
 end

--- a/app/models/concerns/with_territorial_zones.rb
+++ b/app/models/concerns/with_territorial_zones.rb
@@ -4,6 +4,7 @@ module WithTerritorialZones
   included do
     has_many :territorial_zones, as: :zoneable, dependent: :destroy, inverse_of: :zoneable
     accepts_nested_attributes_for :territorial_zones, allow_destroy: true
+    validates_associated :territorial_zones, on: :import
 
     scope :by_region, -> (region_code) {
       return all if region_code.blank?

--- a/app/models/territorial_zone.rb
+++ b/app/models/territorial_zone.rb
@@ -67,31 +67,27 @@ class TerritorialZone < ApplicationRecord
   private
 
   def validate_code_format
-    error_message = I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: zone_type)
-    case zone_type
-    when 'commune'
-      errors.add(:code, error_message) unless code.match?(/^(?:[0-9]{2}[0-9]{3}|2[AB][0-9]{3})$/)
-    when 'departement'
-      errors.add(:code, error_message) unless code.match?(/^(?:[0-9]{2}|2[AB]|[0-9]{3})$/)
-    when 'region'
-      errors.add(:code, error_message) unless code.match?(/^(?:\d{2}|9[78]\d)$/)
-    when 'epci'
-      errors.add(:code, error_message) unless code.match?(/^\d{9}$/)
-    end
+    regex = {
+      'commune' => /^(?:[0-9]{2}[0-9]{3}|2[AB][0-9]{3})$/,
+      'departement' => /^(?:[0-9]{2}|2[AB]|[0-9]{3})$/,
+      'region' => /^(?:\d{2}|9[78]\d)$/,
+      'epci' => /^\d{9}$/
+    }[zone_type]
+
+    errors.add(:code, :invalid_format, zone_type: zone_type, code: code) unless code.match?(regex)
   end
 
   def validate_existence
-    zone = I18n.t(zone_type, scope: 'activerecord.attributes.territorial_zone').capitalize
-    error_message = I18n.t('activerecord.errors.models.territorial_zones.code.not_found', zone_type: zone)
+    zone = I18n.t(zone_type, scope: 'activerecord.attributes.territorial_zone')
 
     model_class = ZONE_TYPE_MODELS[zone_type]
-    return errors.add(:code, error_message) unless model_class
+    return errors.add(:code, :not_found, zone_type: zone, code: code) unless model_class
 
     begin
       model = model_class.find(code)
-      return errors.add(:code, error_message) if model.nil?
+      return errors.add(:code, :not_found, zone_type: zone, code: code) if model.nil?
     rescue DecoupageAdministratif::NotFoundError
-      errors.add(:code, error_message)
+      errors.add(:code, :not_found, zone_type: zone, code: code)
     end
   end
 

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -137,14 +137,15 @@ module CsvImport
     private
 
     def import_specific_territories(expert, attributes)
-      expert.territorial_zones = []
+      expert.territorial_zones.delete_all
       zone_types = %w[commune epci departement region]
       zone_types.each do |zone_type|
         next if attributes[:"custom_#{zone_type}s"].blank?
 
-        expert.territorial_zones += attributes[:"custom_#{zone_type}s"].split(",").map do |code|
-          expert.territorial_zones.find_or_create_by(zone_type: zone_type, code: code.strip)
+        db_attributes = attributes[:"custom_#{zone_type}s"].split(",").map do |code|
+          { zone_type: zone_type, code: code.strip }
         end
+        expert.territorial_zones.insert_all(db_attributes)
       end
     end
   end

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -142,7 +142,7 @@ module CsvImport
       zone_types.each do |zone_type|
         next if attributes[:"custom_#{zone_type}s"].blank?
 
-        db_attributes = attributes[:"custom_#{zone_type}s"].split(",").map do |code|
+        db_attributes = attributes[:"custom_#{zone_type}s"].split(",").uniq.map do |code|
           { zone_type: zone_type, code: code.strip }
         end
         expert.territorial_zones.insert_all(db_attributes)

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -801,10 +801,11 @@ fr:
             email_type:
               bad_quality: ne peut pas être 'bad_quality' car ce type d'email est réservé.
               invalid: doit être composé uniquement de lettres minuscules, chiffres et tirets du bas (_)
-        territorial_zones:
-          code:
-            invalid_format: Format pour %{zone_type} est invalide.
-            not_found: "%{zone_type} non trouvé"
+        territorial_zone:
+          attributes:
+            code:
+              invalid_format: Format pour %{zone_type} (%{code}) est invalide.
+              not_found: "%{zone_type} %{code} non trouvé"
         territory:
           attributes:
             insee_codes:
@@ -1273,6 +1274,7 @@ fr:
     territorial_antennes: Antennes du territoires
     territorial_level: Niveau territorial
     territorial_zone: Zone d’intervention
+    territorial_zones: Zones d’intervention
     territories:
       one: Territoire
       other: Territoires

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -1350,6 +1350,10 @@ fr:
       transmitted_header: Transmission des besoins déposés sur la période
   deleted_account:
     full_name: "(Compte supprimé)"
+  errors:
+    attributes:
+      territorial_zones:
+        not_found: "%{zone_type} %{codes} non trouvé(s)"
   flash:
     actions:
       create:

--- a/spec/models/territorial_zone_spec.rb
+++ b/spec/models/territorial_zone_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TerritorialZone do
         it 'is invalid if code does not match INSEE format' do
           expect(valid_commune).to be_valid
           expect(invalid_commune).not_to be_valid
-          expect(invalid_commune.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: :commune))
+          expect(invalid_commune.errors.details[:code]).to include(error: :invalid_format, zone_type: "commune", code: "123")
         end
       end
 
@@ -21,7 +21,7 @@ RSpec.describe TerritorialZone do
         it 'is invalid if code does not match department format' do
           expect(valid_departement).to be_valid
           expect(invalid_departement).not_to be_valid
-          expect(invalid_departement.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: :departement))
+          expect(invalid_departement.errors.details[:code]).to include(error: :invalid_format, zone_type: "departement", code: "1")
         end
       end
 
@@ -33,7 +33,7 @@ RSpec.describe TerritorialZone do
           it 'is invalid if code does not match region format' do
             expect(valid_region).to be_valid
             expect(invalid_region).not_to be_valid
-            expect(invalid_region.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: :region))
+            expect(invalid_region.errors.details[:code]).to include(error: :invalid_format, zone_type: "region", code: "1")
           end
         end
 
@@ -44,7 +44,7 @@ RSpec.describe TerritorialZone do
           it 'is invalid if code does not match region format' do
             expect(valid_region).to be_valid
             expect(invalid_region).not_to be_valid
-            expect(invalid_region.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: :region))
+            expect(invalid_region.errors.details[:code]).to include(error: :invalid_format, zone_type: "region", code: "123")
           end
         end
       end
@@ -56,7 +56,7 @@ RSpec.describe TerritorialZone do
         it 'is invalid if code does not match EPCI format' do
           expect(valid_epci).to be_valid
           expect(invalid_epci).not_to be_valid
-          expect(invalid_epci.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.invalid_format', zone_type: :epci))
+          expect(invalid_epci.errors.details[:code]).to include(error: :invalid_format, zone_type: "epci", code: "123")
         end
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe TerritorialZone do
 
           it 'is invalid' do
             expect(invalid_commune).not_to be_valid
-            expect(invalid_commune.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.not_found', zone_type: "Commune"))
+            expect(invalid_commune.errors.details[:code]).to include(error: :not_found, zone_type: "Commune", code: "99999")
           end
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe TerritorialZone do
 
           it 'is invalid' do
             expect(invalid_departement).not_to be_valid
-            expect(invalid_departement.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.not_found', zone_type: "Département"))
+            expect(invalid_departement.errors.details[:code]).to include(error: :not_found, zone_type: "Département", code: "98")
           end
         end
       end
@@ -133,7 +133,7 @@ RSpec.describe TerritorialZone do
 
           it 'is invalid' do
             expect(invalid_region).not_to be_valid
-            expect(invalid_region.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.not_found', zone_type: "Région"))
+            expect(invalid_region.errors.details[:code]).to eq [{ error: :not_found, zone_type: "Région", code: "98" }]
           end
         end
       end
@@ -154,7 +154,7 @@ RSpec.describe TerritorialZone do
 
           it 'is invalid' do
             expect(invalid_epci).not_to be_valid
-            expect(invalid_epci.errors[:code]).to include(I18n.t('activerecord.errors.models.territorial_zones.code.not_found', zone_type: "Epci"))
+            expect(invalid_epci.errors.details[:code]).to include(error: :not_found, zone_type: "EPCI", code: "98")
           end
         end
       end

--- a/spec/services/csv_import/antenne_importer_spec.rb
+++ b/spec/services/csv_import/antenne_importer_spec.rb
@@ -42,7 +42,7 @@ describe CsvImport::AntenneImporter, CsvImport do
     it do
       expect(result).not_to be_success
       expect(result.header_errors).to be_empty
-      expect(result.postprocess_errors.first).to eq("Échec de l’import : Erreur lors du post-traitement de l'antenne : La validation a échoué : Code Format pour commune est invalide., Code Commune non trouvé")
+      expect(result.postprocess_errors.first).to eq("Échec de l’import : Erreur lors du post-traitement de l'antenne : La validation a échoué : Code Format pour commune (invalid_code) est invalide., Code Commune invalid_code non trouvé")
     end
   end
 


### PR DESCRIPTION
fixes #4648, #4649

| | Perf | Erreur |
|-|-|-|
| Avant: | `Completed 422 Unprocessable Content in 128380ms (Views: 516.6ms ActiveRecord: 4845.3ms (5437 queries, 24 cached)` | <img width="520" height="80" alt="image" src="https://github.com/user-attachments/assets/6a2338a2-a7b7-4373-a151-bce30d64cdee" /> |
| Après: | `Completed 422 Unprocessable Content in 1343ms (Views: 504.5ms ActiveRecord: 343.5ms (376 queries, 45 cached) ` | <img width="528" height="79" alt="image" src="https://github.com/user-attachments/assets/c13d907f-f70c-4d6a-a8f0-9f2af261498d" /> |

Cette PR:
- indique les valeurs des codes inexistants dans la ligne en erreur,
- réusine la gestion des erreurs pour utiliser les api i18n,
- importe en bulk (en une seule query) les territorial_zones,
- utilise un set des codes insee valides, pour trouver les valeurs invalides en une fois au niveau de l’expert plutôt que chaque territorial_zone. 
  On passe à deux minutes à 1s.

Reste à voir aussi #4146: après l’import, BuildAntennesCollection a le même genre de problème de complexité. 