### PR TITLE
Dupliquer tout le profil expert quand on duplique un utilisateur

### DIFF
--- a/app/admin/duplicate_user.rb
+++ b/app/admin/duplicate_user.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register_page 'Duplicate user' do
       redirect_to admin_users_path and return
     end
     user_params = params.require(:user).permit(:full_name, :email, :phone_number, :job)
-    new_user = old_user.duplicate(user_params)
+    new_user = User.duplicate_from(old_user, user_params)
     if new_user.valid?
       flash[:notice] = t('active_admin.user.created')
       redirect_to admin_users_path
@@ -24,13 +24,39 @@ ActiveAdmin.register_page 'Duplicate user' do
     new_user = User.new(job: old_user.job)
 
     panel t('active_admin.duplicate_user.new_user_details'), class: 'active-admin-form' do
+      div class: "information" do
+        # single-user expert
+        single_user_expert = old_user.single_user_experts.first
+        if single_user_expert.present?
+          div t('active_admin.duplicate_user.old_user_has_single_expert', user: old_user)
+          # territorial zones
+          if single_user_expert.territorial_zones.any?
+            div t('active_admin.duplicate_user.old_expert_has_territorial_zones')
+          end
+          # match filters
+          if single_user_expert.match_filters.any?
+            div t('active_admin.duplicate_user.old_expert_has_match_filters', count: single_user_expert.match_filters.size)
+          end
+        end
+        # teams
+        teams = old_user.experts.with_many_users
+        if teams.any?
+          div t('active_admin.duplicate_user.old_user_has_teams', user: old_user, teams: teams.map(&:to_s).to_sentence, count: teams.size)
+        end
+        # user rights
+        user_rights = old_user.user_rights
+        if user_rights.any?
+          div t('active_admin.duplicate_user.old_user_has_user_rights', user: old_user, count: user_rights.size)
+        end
+      end
+
       table do
         active_admin_form_for new_user, url: admin_user_duplicate_user_duplicate_path do |f|
           f.input :full_name, input_html: { required: true }
           f.input :job
           f.input :email, input_html: { required: true }
           f.input :phone_number
-          f.submit
+          f.submit t('active_admin.duplicate_user.submit')
         end
       end
     end

--- a/app/admin/duplicate_user.rb
+++ b/app/admin/duplicate_user.rb
@@ -11,10 +11,13 @@ ActiveAdmin.register_page 'Duplicate user' do
     user_params = params.require(:user).permit(:full_name, :email, :phone_number, :job)
     new_user = User.duplicate_from(old_user, user_params)
     if new_user.valid?
-      message_1 = t('active_admin.duplicate_user.completed', new_user: new_user)
-      message_2 = t('active_admin.duplicate_user.completed_reassign_matches', old_user: old_user)
-      reassign_path = admin_expert_reassign_matches_path(old_user.single_user_experts.first, selected_expert_id: new_user.single_user_experts.first.id)
-      flash[:notice] = "#{message_1} #{helpers.link_to message_2, reassign_path}"
+      message = t('active_admin.duplicate_user.completed', new_user: new_user)
+      if old_user.single_user_experts&.first&.received_matches&.in_progress.present? # Suggest to reassign in-progress matches
+        message_2 = t('active_admin.duplicate_user.completed_reassign_matches', old_user: old_user)
+        reassign_path = admin_expert_reassign_matches_path(old_user.single_user_experts.first, selected_expert_id: new_user.single_user_experts.first.id)
+        message = "#{message} #{helpers.link_to message_2, reassign_path}"
+      end
+      flash[:notice] = message
       redirect_to admin_user_path(new_user)
     else
       flash[:alert] = new_user.errors.full_messages.to_sentence

--- a/app/admin/duplicate_user.rb
+++ b/app/admin/duplicate_user.rb
@@ -5,14 +5,17 @@ ActiveAdmin.register_page 'Duplicate user' do
   page_action :duplicate, method: :post do
     old_user = User.find(params[:user_id])
     if old_user.deleted?
-      flash[:alert] = I18n.t('active_admin.duplicate_user.deleted_user')
+      flash[:alert] = t('active_admin.duplicate_user.deleted_user')
       redirect_to admin_users_path and return
     end
     user_params = params.require(:user).permit(:full_name, :email, :phone_number, :job)
     new_user = User.duplicate_from(old_user, user_params)
     if new_user.valid?
-      flash[:notice] = t('active_admin.user.created')
-      redirect_to admin_users_path
+      message_1 = t('active_admin.duplicate_user.completed', new_user: new_user)
+      message_2 = t('active_admin.duplicate_user.completed_reassign_matches', old_user: old_user)
+      reassign_path = admin_expert_reassign_matches_path(old_user.single_user_experts.first, selected_expert_id: new_user.single_user_experts.first.id)
+      flash[:notice] = "#{message_1} #{helpers.link_to message_2, reassign_path}"
+      redirect_to admin_user_path(new_user)
     else
       flash[:alert] = new_user.errors.full_messages.to_sentence
       redirect_to admin_user_duplicate_user_path(old_user)

--- a/app/admin/duplicate_user.rb
+++ b/app/admin/duplicate_user.rb
@@ -20,16 +20,14 @@ ActiveAdmin.register_page 'Duplicate user' do
   end
 
   content title: I18n.t('active_admin.duplicate_user.title') do
+    old_user = User.find(params[:user_id])
+    new_user = User.new(job: old_user.job)
+
     panel t('active_admin.duplicate_user.new_user_details'), class: 'active-admin-form' do
       table do
-        new_user = User.new
-        user = User.find(params[:user_id])
         active_admin_form_for new_user, url: admin_user_duplicate_user_duplicate_path do |f|
           f.input :full_name, input_html: { required: true }
-          li do
-            f.label :job
-            f.text_field :job, value: user.job
-          end
+          f.input :job
           f.input :email, input_html: { required: true }
           f.input :phone_number
           f.submit

--- a/app/admin/duplicate_user.rb
+++ b/app/admin/duplicate_user.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page 'Duplicate user' do
       flash[:alert] = I18n.t('active_admin.duplicate_user.deleted_user')
       redirect_to admin_users_path and return
     end
-    user_params = params.require(:user).permit(:full_name, :email, :phone_number, :job, :specifics_territories)
+    user_params = params.require(:user).permit(:full_name, :email, :phone_number, :job)
     new_user = old_user.duplicate(user_params)
     if new_user.valid?
       flash[:notice] = t('active_admin.user.created')
@@ -32,9 +32,6 @@ ActiveAdmin.register_page 'Duplicate user' do
           end
           f.input :email, input_html: { required: true }
           f.input :phone_number
-          if user.experts.map(&:custom_territories?).any?
-            f.input :specifics_territories, as: :boolean, label: I18n.t('active_admin.user.duplicate_territories')
-          end
           f.submit
         end
       end

--- a/app/admin/patches/flash_messages.rb
+++ b/app/admin/patches/flash_messages.rb
@@ -1,0 +1,13 @@
+module Admin
+  module Patches
+    module FlashMessages
+      ## !! Monkey-patch override !!
+      # Sanitize the flash messages to allow (some) html
+      def flash_messages
+        super.transform_values { sanitize it }
+      end
+    end
+
+    ActiveAdmin::ViewHelpers.include FlashMessages
+  end
+end

--- a/app/admin/reassign_matches.rb
+++ b/app/admin/reassign_matches.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register_page 'Reassign matches' do
     selected_expert = Expert.find(params[:selected_expert_id])
     begin
       result = old_expert.reassign_matches(selected_expert)
-      flash[:notice] = t('active_admin.expert.reassign_matches_done', count: result.count, expert: selected_expert)
+      flash[:notice] = t('active_admin.expert.reassign_matches_done', count: result.count, expert: helpers.link_to(selected_expert, admin_expert_path(selected_expert)))
       redirect_to admin_expert_path(old_expert)
     rescue StandardError => e
       flash[:alert] = I18n.t('activerecord.attributes.expert.errors.cant_transfer_match', error: e.message)

--- a/app/assets/stylesheets/active_admin.sass
+++ b/app/assets/stylesheets/active_admin.sass
@@ -227,6 +227,15 @@ body.active_admin nav.pagination
       margin: 0.5rem 0.5rem 0.5rem 0
 
 .panel_contents
+  .information
+    background-color: #dce9dd
+    color: #416347
+    padding: 1em
+    margin-block-end: 1em
+    display: flex
+    flex-direction: column
+    gap: 1em
+
   .actions
     list-style: none
     li

--- a/app/models/concerns/duplicate_user.rb
+++ b/app/models/concerns/duplicate_user.rb
@@ -1,0 +1,34 @@
+module DuplicateUser
+  def duplicate_from(old_user, params)
+    self.transaction do
+      new_user = new(params)
+      new_user.antenne = old_user.antenne
+      new_user.save!
+
+      # single-user expert
+      old_single_user_expert = old_user.single_user_experts.first
+      if old_single_user_expert.present?
+        new_single_user_expert = new_user.create_single_user_experts
+        # territorial zones
+        if old_single_user_expert.territorial_zones.any?
+          db_attributes = old_single_user_expert.territorial_zones.map{ it.attributes.except("id", "created_at", "updated_at") }
+          new_single_user_expert.territorial_zones.insert_all(db_attributes)
+        end
+        # match filters
+        if old_single_user_expert.match_filters.any?
+          db_attributes = old_single_user_expert.match_filters.map{ it.attributes.except("id", "created_at", "updated_at") }
+          new_single_user_expert.match_filters.insert_all(db_attributes)
+        end
+      end
+
+      # teams
+      new_user.experts << old_user.experts.with_many_users
+
+      # user rights
+      db_attributes = old_user.user_rights.map{ it.attributes.except("id", "created_at", "updated_at") }
+      new_user.user_rights.insert_all(db_attributes)
+
+      new_user
+    end
+  end
+end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -94,6 +94,12 @@ class Expert < ApplicationRecord
       .having("COUNT(users.id)=1")
   end
 
+  scope :with_many_users, -> do
+    joins(:users)
+      .group(:id)
+      .having("COUNT(users.id)>1")
+  end
+
   scope :with_users, -> { joins(:users) }
 
   # On s'appuie sur table de jointure pour éviter les faux positifs
@@ -289,6 +295,10 @@ class Expert < ApplicationRecord
 
   def without_users?
     users.empty?
+  end
+
+  def with_many_users?
+    users.size > 1
   end
 
   def with_one_user?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,7 @@ class User < ApplicationRecord
   include InvolvementConcern
   include SoftDeletable
   include Monitoring
+  extend DuplicateUser
 
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :async,
          :validatable,
@@ -327,19 +328,6 @@ class User < ApplicationRecord
 
   def is_admin?
     user_rights_admin.any?
-  end
-
-  def duplicate(params)
-    params[:job] ||= self.job
-    new_user = User.create(params.merge(antenne: antenne))
-    return new_user unless new_user.valid?
-    user_experts = self.experts
-    if user_experts.present?
-      new_user.experts.concat(user_experts)
-      new_user.save
-    end
-    self.user_rights.each { |right| right.dup.update(user_id: new_user.id) }
-    new_user
   end
 
   def supervised_antennes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
          :validatable,
          :invitable, invited_by_class_name: 'User', validate_on_invite: true
 
-  attr_accessor :cgu_accepted, :specifics_territories, :create_expert
+  attr_accessor :cgu_accepted, :create_expert
 
   APP_INFO_KEYS = %w[bascule_seen questionnaire_2026_seen questionnaire_2026_done]
   store_accessor :app_info, APP_INFO_KEYS

--- a/app/views/admin/reassign_matches/_reassign_matches.html.haml
+++ b/app/views/admin/reassign_matches/_reassign_matches.html.haml
@@ -4,6 +4,7 @@
       .active-admin-form.panel
         %h3= t('.select_expert')
         .panel_contents
+          %p.information= t('.matches_to_reassign', count: expert.received_matches.in_progress.count)
           = form_with(url: admin_expert_reassign_matches_reassign_path, local: true) do |f|
             %li.input.required.stringish
               = f.select(:selected_expert_id, options_from_collection_for_select(expert.antenne.experts, :id, :full_name, params[:selected_expert_id]))

--- a/app/views/admin/reassign_matches/_reassign_matches.html.haml
+++ b/app/views/admin/reassign_matches/_reassign_matches.html.haml
@@ -6,5 +6,5 @@
         .panel_contents
           = form_with(url: admin_expert_reassign_matches_reassign_path, local: true) do |f|
             %li.input.required.stringish
-              = f.select(:selected_expert_id, options_from_collection_for_select(expert.antenne.experts, :id, :full_name))
+              = f.select(:selected_expert_id, options_from_collection_for_select(expert.antenne.experts, :id, :full_name, params[:selected_expert_id]))
             = f.submit t('.save')

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -181,7 +181,6 @@ fr:
       connection: Connexion
       create_expert: Créer un expert identique
       create_expert_done: L’expert a bien été créé
-      created: Utilisateur créé avec succès
       delete: Supprimer l’utilisateur
       delete_confirmation:
         one: Voulez-vous supprimer cet utilisateur ? Cela va aussi supprimer son équipe individuelle.

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -191,7 +191,6 @@ fr:
       do_invite_done: Invitation(s) envoyée(s)
       do_reset_password: Réinitialiser le mot de passe
       do_reset_password_done: Réinitialisation du mot de passe envoyée
-      duplicate_territories: Dupliquer les territoires spécifiques
       impersonate: Voir le site comme %{name}
       invite_to_demo: Inviter à une démo
       invited_to_demo: Invitation(s) à la démo envoyée(s)

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -46,7 +46,7 @@ fr:
     csv_export_launched: La génération du CSV a commencé, retrouvez-le dans quelques minutes dans votre espace personnel.
     duplicate_user:
       completed: Utilisateur %{new_user} créé.
-      completed_reassign_matches: Réassigner les mises en relations de %{old_user}?
+      completed_reassign_matches: Réassigner les mises en relations de %{old_user} ?
       deleted_user: Cet utilisateur a été supprimé, cette action n'est donc pas possible
       new_user_details: Coordonnées du nouvel utilisateur
       old_expert_has_match_filters:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -45,6 +45,8 @@ fr:
     csv_export: Export CSV
     csv_export_launched: La génération du CSV a commencé, retrouvez-le dans quelques minutes dans votre espace personnel.
     duplicate_user:
+      completed: Utilisateur %{new_user} créé.
+      completed_reassign_matches: Réassigner les mises en relations de %{old_user}?
       deleted_user: Cet utilisateur a été supprimé, cette action n'est donc pas possible
       new_user_details: Coordonnées du nouvel utilisateur
       old_expert_has_match_filters:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -82,6 +82,10 @@ fr:
   admin:
     reassign_matches:
       reassign_matches:
+        matches_to_reassign:
+          one: "%{count} mise en relation à réassigner."
+          other: "%{count} mises en relation à réassigner."
+          zero: Aucune mise en relation à réassigner.
         save: Enregistrer
         select_expert: Expert pour la réatribution des mises en relation
   admin_link: Lien admin

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -47,6 +47,18 @@ fr:
     duplicate_user:
       deleted_user: Cet utilisateur a été supprimé, cette action n'est donc pas possible
       new_user_details: Coordonnées du nouvel utilisateur
+      old_expert_has_match_filters:
+        one: Ce profil expert a un filtre de mise en relation. Il sera copié dans le nouvel expert.
+        other: Ce profil expert a des filtres de mise en relation. Ils seront copiés dans le nouvel expert.
+      old_expert_has_territorial_zones: Ce profil expert a une zone d’intervention spécifique. Elle sera copiée dans le nouvel expert.
+      old_user_has_single_expert: "%{user} a son propre profil expert, qui va être dupliqué pour le nouvel utilisateur."
+      old_user_has_teams:
+        one: "%{user} fait partie de l’équipe %{teams}. Le nouvel utilisateur sera affecté à cette équipe."
+        other: "%{user} fait partie des équipes %{teams}. Le nouvel utilisateur sera affecté à ces équipes."
+      old_user_has_user_rights:
+        one: "%{user} a un rôle spécifique. Il sera copié dans le nouvel utilisateur."
+        other: "%{user} a des rôles spécifiques. Ils seront copiés dans le nouvel utilisateur."
+      submit: Créer un nouvel utilisateur
       title: Dupliquer un utilisateur
     reassign_matches:
       title: Transférer les mises en relation

--- a/spec/models/concerns/duplicate_user_spec.rb
+++ b/spec/models/concerns/duplicate_user_spec.rb
@@ -31,10 +31,8 @@ RSpec.describe DuplicateUser do
       # match filters
       expect(new_expert.match_filters.first.min_years_of_existence).to eq 2
       expect(new_expert.match_filters.first.id).not_to eq old_expert.match_filters.first.id
-
       # teams
       expect(new_user.experts).to include old_team
-
       # user rights
       expect(new_user.user_rights.first.category).to eq "manager"
       expect(new_user.user_rights.first.id).not_to eq old_user.user_rights.first.id

--- a/spec/models/concerns/duplicate_user_spec.rb
+++ b/spec/models/concerns/duplicate_user_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe DuplicateUser do
+  describe '#duplicate_from' do
+    let(:old_user) { create(:user, experts: [old_expert, old_team], user_rights: [build(:user_right, category: :manager, antenne: antenne)]) }
+    let(:antenne) { build(:antenne) }
+    let(:old_expert) do
+      build(:expert,
+             territorial_zones: [build(:territorial_zone, zone_type: "departement", code: "22")],
+             match_filters: [build(:match_filter, min_years_of_existence: 2)])
+    end
+    let(:old_team) { build(:expert, users: build_list(:user, 2)) }
+    let(:params) { { full_name: "My Name", email: "email@example.com", job: "My Job" } }
+
+    it do
+      new_user = User.duplicate_from(old_user, params)
+
+      expect(new_user.full_name).to eq "My Name"
+      expect(new_user.email).to eq "email@example.com"
+      expect(new_user.job).to eq "My Job"
+
+      expect(new_user.antenne).to eq old_user.antenne
+
+      # single-user expert
+      expect(new_user.experts).not_to include old_expert
+      new_expert = new_user.single_user_experts.first
+      expect(new_expert).not_to be_nil
+      # territorial zones
+      expect(new_expert.territorial_zones.first.zone_type).to eq "departement"
+      expect(new_expert.territorial_zones.first.id).not_to eq old_expert.territorial_zones.first.id
+      # match filters
+      expect(new_expert.match_filters.first.min_years_of_existence).to eq 2
+      expect(new_expert.match_filters.first.id).not_to eq old_expert.match_filters.first.id
+
+      # teams
+      expect(new_user.experts).to include old_team
+
+      # user rights
+      expect(new_user.user_rights.first.category).to eq "manager"
+      expect(new_user.user_rights.first.id).not_to eq old_user.user_rights.first.id
+    end
+  end
+end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -47,8 +47,23 @@ RSpec.describe Expert do
 
       it do
         is_expected.to be_with_one_user
+        is_expected.not_to be_with_many_users
         is_expected.not_to be_without_users
         expect(described_class.with_one_user).to include(expert)
+        expect(described_class.with_many_users).not_to include(expert)
+        expect(described_class.without_users).not_to include(expert)
+      end
+    end
+
+    context 'an expert with several user is a team' do
+      let(:expert_users) { [user, user2] }
+
+      it do
+        is_expected.not_to be_with_one_user
+        is_expected.to be_with_many_users
+        is_expected.not_to be_without_users
+        expect(described_class.with_one_user).not_to include(expert)
+        expect(described_class.with_many_users).to include(expert)
         expect(described_class.without_users).not_to include(expert)
       end
     end
@@ -58,8 +73,10 @@ RSpec.describe Expert do
 
       it do
         is_expected.not_to be_with_one_user
+        is_expected.not_to be_with_many_users
         is_expected.to be_without_users
         expect(described_class.with_one_user).not_to include(expert)
+        expect(described_class.with_many_users).not_to include(expert)
         expect(described_class.without_users).to include(expert)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -249,32 +249,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#duplicate' do
-    let(:institution) { create :institution }
-    let(:antenne) { create :antenne, institution: institution }
-    let(:a_subject) { create :subject }
-    let(:institution_subject) { create :institution_subject, institution: institution, subject: a_subject }
-    let(:expert_subject) { create :expert_subject, institution_subject: institution_subject }
-    let(:old_user) { create :user, :invitation_accepted, :manager, experts: [expert], antenne: antenne, full_name: 'Old User' }
-
-    context 'with team' do
-      let(:expert) { create :expert_with_users, experts_subjects: [expert_subject], antenne: antenne }
-      let(:new_user) { old_user.duplicate({ full_name: 'New User', email: 'test1@email.com', phone_number: '0303030303' }) }
-
-      it "duplicate a user and add it to old_user team" do
-        expect(new_user.full_name).to eq 'New User'
-        expect(new_user.email).to eq 'test1@email.com'
-        expect(new_user.phone_number).to eq '03 03 03 03 03'
-        expect(new_user.job).to eq old_user.job
-        expect(new_user.antenne).to eq old_user.antenne
-        expect(new_user.antenne.experts.count).to eq 1
-        expect(new_user.experts.map { |e| e.subjects }.flatten).to contain_exactly(a_subject)
-        expect(new_user.experts).to contain_exactly(expert)
-        expect(new_user.user_rights.count).to eq 1
-      end
-    end
-  end
-
   describe '#support_user' do
     # Si responsable d'une antenne national => referent principal
     # autres cas => referent de l'antenne


### PR DESCRIPTION
fixes #4566 

On copie:
- les user_rights de l’utilisateur
- l’expert “individuel”, avec:
  - sa zone d’intervention
  - ses filtres de mise en relation

Et on réassigne l’ancien expert “équipe”, le cas échéant.


Il y a maintenant une petite description avant la duplication, qui indique ce qui va se passer:

<img width="792" height="471" alt="image" src="https://github.com/user-attachments/assets/8ec2644d-3fb3-499f-a7ee-ce0549736b7b" />

Et après la duplication, on peut directement accéder à la page de réassignement des mises en relation en cours:

<img width="608" height="92" alt="image" src="https://github.com/user-attachments/assets/6fcdaf12-0c6d-426a-b721-11dcf36ee34e" />
