### PR TITLE
Corrige la page export des MER pour les antennes nationales

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -27,7 +27,8 @@ class ReportsController < ApplicationController
   def retrieve_antenne
     @antennes = BuildAntennesCollection.new(current_user).for_manager_or_sponsor
     antenne_hash = if params[:antenne_id]
-      @antennes.find{ it[:id].to_s == params.expect(:antenne_id) }
+      requested_id = params.expect(:antenne_id)
+      @antennes.find { it[:id].to_s == requested_id } || @antennes.find { it[:id].to_s == "#{requested_id}-aggregate" }
     else
       @antennes.find { it[:id].to_s.include?('aggregate') } || @antennes.first
     end

--- a/spec/features/reports/reports_feature_spec.rb
+++ b/spec/features/reports/reports_feature_spec.rb
@@ -31,4 +31,17 @@ describe 'reports' do
       expect(page).to have_css('.fr-download__link', count: 3)
     end
   end
+
+  describe 'national antenne with local antennes (aggregated id)' do
+    let!(:institution) { create :institution }
+    let!(:national_antenne) { create :antenne, :national, institution: institution, managers: [current_user] }
+    let!(:local_antenne) { create :antenne, :local, institution: institution }
+    let!(:category_stats) { create :activity_report, :category_stats, reportable: national_antenne, start_date: Date.new(2024, 01, 01), end_date: Date.new(2024, 03, 31) }
+
+    it 'falls back to the aggregated antenne when visiting with the plain antenne id' do
+      visit stats_reports_path(antenne_id: national_antenne.id)
+
+      expect(page.html).to include I18n.t('reports.stats.title', antenne: national_antenne.name)
+    end
+  end
 end


### PR DESCRIPTION
closes #4658 

Si dans @antennes il y avait une seule antenne agrégée on avait une erreur `undefined method '[]' for nil`