### PR TITLE
amélioration des perf des stats  1/3 : partie aquisition

### DIFF
--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -330,6 +330,14 @@ class Solicitation < ApplicationRecord
       .or(where("solicitations.form_info::json->>'mtm_campaign' ILIKE ?", "%#{query}%"))
   }
 
+  # Same match as `mtm_campaign_cont`, but returned as a raw SQL fragment so it can
+  # be reused inside an aggregate `FILTER (WHERE …)` (stats), where a relation can't be passed.
+  def self.mtm_campaign_cont_sql(value)
+    escaped = sanitize_sql_like(value)
+    "(solicitations.form_info::json->>'pk_campaign' ILIKE '%#{escaped}%' " \
+      "OR solicitations.form_info::json->>'mtm_campaign' ILIKE '%#{escaped}%')"
+  end
+
   scope :mtm_kwd_eq, -> (query) {
     where('form_info @> ?', { pk_kwd: query }.to_json)
       .or(where('form_info @> ?', { mtm_kwd: query }.to_json))
@@ -430,6 +438,13 @@ class Solicitation < ApplicationRecord
   # Scope for stats
   scope :from_integration, -> (integration) do
     joins(:landing).where(landings: { integration: integration })
+  end
+
+  # Solicitations whose landing has the given integration, as a join-free SQL
+  # fragment (subquery) so it can be reused inside an aggregate `FILTER (WHERE …)`
+  # (stats) without joining `landings`.
+  def self.from_integration_sql(integration)
+    "solicitations.landing_id IN (#{Landing.where(integration: integration).select(:id).to_sql})"
   end
 
   def self.apply_filters(params)

--- a/app/services/stats/acquisitions/base.rb
+++ b/app/services/stats/acquisitions/base.rb
@@ -7,11 +7,12 @@ module Stats::Acquisitions::Base
 
   def aggregate_filters
     {
-      from_entreprendre: campaign_condition('entreprendre'),
-      from_google_ads: campaign_condition('googleads'),
-      from_iframes: integration_condition(:iframe),
-      from_redirections: "(#{campaign_condition('orientation-partenaire')} OR #{campaign_condition('compartenaire')})",
-      from_api: integration_condition(:api),
+      from_entreprendre: Solicitation.mtm_campaign_cont_sql('entreprendre'),
+      from_google_ads: Solicitation.mtm_campaign_cont_sql('googleads'),
+      from_iframes: Solicitation.from_integration_sql(:iframe),
+      from_redirections: "(#{Solicitation.mtm_campaign_cont_sql('orientation-partenaire')} OR " \
+                         "#{Solicitation.mtm_campaign_cont_sql('compartenaire')})",
+      from_api: Solicitation.from_integration_sql(:api),
     }
   end
 
@@ -35,17 +36,5 @@ module Stats::Acquisitions::Base
 
   def columns_colors
     %w[#cecece #c9191e #F1C40F #AFD2E9 #A8C256 #345995]
-  end
-
-  private
-
-  def campaign_condition(value)
-    escaped_value = ActiveRecord::Base.sanitize_sql_like(value)
-    "(solicitations.form_info::json->>'pk_campaign' ILIKE '%#{escaped_value}%' " \
-      "OR solicitations.form_info::json->>'mtm_campaign' ILIKE '%#{escaped_value}%')"
-  end
-
-  def integration_condition(integration)
-    "solicitations.landing_id IN (#{Landing.where(integration: integration).select(:id).to_sql})"
   end
 end

--- a/app/services/stats/acquisitions/base.rb
+++ b/app/services/stats/acquisitions/base.rb
@@ -40,8 +40,9 @@ module Stats::Acquisitions::Base
   private
 
   def campaign_condition(value)
-    "(solicitations.form_info::json->>'pk_campaign' ILIKE '%#{value}%' " \
-      "OR solicitations.form_info::json->>'mtm_campaign' ILIKE '%#{value}%')"
+    escaped_value = ActiveRecord::Base.sanitize_sql_like(value)
+    "(solicitations.form_info::json->>'pk_campaign' ILIKE '%#{escaped_value}%' " \
+      "OR solicitations.form_info::json->>'mtm_campaign' ILIKE '%#{escaped_value}%')"
   end
 
   def integration_condition(integration)

--- a/app/services/stats/acquisitions/base.rb
+++ b/app/services/stats/acquisitions/base.rb
@@ -1,40 +1,22 @@
 module Stats::Acquisitions::Base
-  def build_series_for_type(type)
-    query = main_query
-    query = filtered(query)
+  include Stats::Concerns::FilteredAggregates
 
-    @results = Hash.new { |hash, key| hash[key] = [] }
-    @results['from_others'] = [] if type == 'percentage-column-chart'
-
-    search_range_by_month.each do |range|
-      if type == 'percentage-column-chart'
-        build_range_data_with_others(query, range)
-      else
-        build_range_data(query, range)
-      end
-    end
-
-    as_series(@results)
+  def build_series
+    build_filtered_series
   end
 
-  def build_range_data(query, range)
-    month_query = month_query(query, range)
-    @results['from_entreprendre'] << month_query.mtm_campaign_cont('entreprendre').count
-    @results['from_google_ads'] << month_query.mtm_campaign_cont('googleads').count
-    @results['from_iframes'] << month_query.from_integration('iframe').count
-    @results['from_redirections'] << month_query.mtm_campaign_cont('orientation-partenaire')
-      .or(month_query.mtm_campaign_cont('compartenaire')).count
-    @results['from_api'] << month_query.from_integration('api').count
+  def aggregate_filters
+    {
+      from_entreprendre: campaign_condition('entreprendre'),
+      from_google_ads: campaign_condition('googleads'),
+      from_iframes: integration_condition(:iframe),
+      from_redirections: "(#{campaign_condition('orientation-partenaire')} OR #{campaign_condition('compartenaire')})",
+      from_api: integration_condition(:api),
+    }
   end
 
-  def build_range_data_with_others(query, range)
-    build_range_data(query, range)
-    @results['from_others'] << (month_query(query, range).count - @results['from_entreprendre'].last - @results['from_google_ads'].last -
-      @results['from_iframes'].last - @results['from_redirections'].last - @results['from_api'].last)
-  end
-
-  def category_group_attribute
-    :status
+  def with_others?
+    chart == 'percentage-column-chart'
   end
 
   def count; end
@@ -57,7 +39,12 @@ module Stats::Acquisitions::Base
 
   private
 
-  def month_query(query, range)
-    query.created_between(range.first, range.last)
+  def campaign_condition(value)
+    "(solicitations.form_info::json->>'pk_campaign' ILIKE '%#{value}%' " \
+      "OR solicitations.form_info::json->>'mtm_campaign' ILIKE '%#{value}%')"
+  end
+
+  def integration_condition(integration)
+    "solicitations.landing_id IN (#{Landing.where(integration: integration).select(:id).to_sql})"
   end
 end

--- a/app/services/stats/acquisitions/by_new_companies.rb
+++ b/app/services/stats/acquisitions/by_new_companies.rb
@@ -1,7 +1,9 @@
 module Stats::Acquisitions
   class ByNewCompanies
     include ::Stats::BaseStats
-    include Stats::Acquisitions::NeedsBase
+    include Stats::Acquisitions::NeedsScope
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
     def main_query
       base_scope.where(status: :done).joins(:solicitation)
@@ -13,49 +15,16 @@ module Stats::Acquisitions
         .select('min(solicitations.id) as id')
     end
 
-    def build_series
-      query = filtered_main_query
-      @from_new_companies = []
-      @from_known_companies = []
-
-      search_range_by_month.each do |range|
-        month_query = month_query(query, range)
-        @from_new_companies.push(month_query
-                                   .where(solicitations: { id: first_solicitations })
-                                   .count)
-        @from_known_companies.push(month_query
-                                     .where.not(solicitations: { id: first_solicitations })
-                                     .count)
-      end
-
-      as_series(@from_known_companies, @from_new_companies)
-    end
-
-    def month_query(query, range)
-      query.created_between(range.first, range.last)
-    end
-
-    def as_series(from_known_companies, from_new_companies)
+    # series[0] = from_known_companies (compared), series[1] = from_new_companies (target)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.from_known_companies'),
-          data: from_known_companies
-        },
-        {
-          name: I18n.t('stats.from_new_companies'),
-          data: from_new_companies
-        }
+        [:from_known_companies, :else],
+        [:from_new_companies, "solicitations.id IN (#{first_solicitations.to_sql})"]
       ]
     end
 
-    def count
-      series
-      percentage_two_numbers(@from_new_companies, @from_known_companies)
-    end
-
-    def secondary_count
-      series
-      @from_new_companies.sum
+    def category_name(key)
+      I18n.t("stats.#{key}")
     end
 
     def colors

--- a/app/services/stats/acquisitions/needs_base.rb
+++ b/app/services/stats/acquisitions/needs_base.rb
@@ -1,24 +1,4 @@
 module Stats::Acquisitions::NeedsBase
+  include Stats::Acquisitions::NeedsScope
   include Stats::Acquisitions::Base
-
-  def base_scope
-    Need.diagnosis_completed
-      .joins(diagnosis: { solicitation: :landing }).merge(Diagnosis.from_solicitation)
-      .where(created_at: @start_date..@end_date)
-  end
-
-  def filtered(query)
-    Stats::Filters::Needs.new(query, self).call
-  end
-
-  private
-
-  def as_series(results)
-    results.map do |key, value|
-      {
-        name: I18n.t("stats.series.#{key}.title"),
-        data: value
-      }
-    end
-  end
 end

--- a/app/services/stats/acquisitions/needs_scope.rb
+++ b/app/services/stats/acquisitions/needs_scope.rb
@@ -1,0 +1,11 @@
+module Stats::Acquisitions::NeedsScope
+  def base_scope
+    Need.diagnosis_completed
+      .joins(diagnosis: { solicitation: :landing }).merge(Diagnosis.from_solicitation)
+      .where(created_at: @start_date..@end_date)
+  end
+
+  def filtered(query)
+    Stats::Filters::Needs.new(query, self).call
+  end
+end

--- a/app/services/stats/acquisitions/overall_distribution_needs_done_with_help.rb
+++ b/app/services/stats/acquisitions/overall_distribution_needs_done_with_help.rb
@@ -7,10 +7,6 @@ module Stats::Acquisitions
       base_scope.where(status: :done)
     end
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       lines_colors
     end

--- a/app/services/stats/acquisitions/overall_distribution_needs_done_with_help_column.rb
+++ b/app/services/stats/acquisitions/overall_distribution_needs_done_with_help_column.rb
@@ -7,10 +7,6 @@ module Stats::Acquisitions
       base_scope.where(status: :done)
     end
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       columns_colors
     end

--- a/app/services/stats/acquisitions/overall_distribution_needs_transmitted.rb
+++ b/app/services/stats/acquisitions/overall_distribution_needs_transmitted.rb
@@ -7,10 +7,6 @@ module Stats::Acquisitions
       base_scope
     end
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       lines_colors
     end

--- a/app/services/stats/acquisitions/overall_distribution_needs_transmitted_column.rb
+++ b/app/services/stats/acquisitions/overall_distribution_needs_transmitted_column.rb
@@ -7,10 +7,6 @@ module Stats::Acquisitions
       base_scope
     end
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       columns_colors
     end

--- a/app/services/stats/acquisitions/overall_distribution_solicitations.rb
+++ b/app/services/stats/acquisitions/overall_distribution_solicitations.rb
@@ -2,10 +2,6 @@ module Stats::Acquisitions
   class OverallDistributionSolicitations
     include Stats::Acquisitions::SolicitationsBase
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       lines_colors
     end

--- a/app/services/stats/acquisitions/overall_distribution_solicitations_column.rb
+++ b/app/services/stats/acquisitions/overall_distribution_solicitations_column.rb
@@ -2,10 +2,6 @@ module Stats::Acquisitions
   class OverallDistributionSolicitationsColumn
     include Stats::Acquisitions::SolicitationsBase
 
-    def build_series
-      build_series_for_type(chart)
-    end
-
     def colors
       columns_colors
     end

--- a/app/services/stats/acquisitions/solicitations_base.rb
+++ b/app/services/stats/acquisitions/solicitations_base.rb
@@ -3,21 +3,10 @@ module Stats::Acquisitions::SolicitationsBase
   include Stats::Acquisitions::Base
 
   def main_query
-    Solicitation.step_complete
+    Solicitation.step_complete.where(created_at: @start_date..@end_date)
   end
 
   def filtered(query)
     Stats::Filters::Solicitations.new(query, self).call
-  end
-
-  private
-
-  def as_series(results)
-    results.map do |key, value|
-      {
-        name: I18n.t("stats.series.#{key}.title"),
-        data: value
-      }
-    end
   end
 end

--- a/app/services/stats/base_stats.rb
+++ b/app/services/stats/base_stats.rb
@@ -147,11 +147,25 @@ module Stats
       category
     end
 
+    # Overridden when a join can inflate rows (e.g. needs joined to matches)
+    def category_count_distinct? # rubocop:disable Naming/PredicateMethod
+      false
+    end
+
+    # Overridden to bucket by another model's date (e.g. matches by needs)
+    def month_group_table(query)
+      query.model.table_name
+    end
+
     private
 
-    def grouped_by_month(query)
+    def month_group_sql(query)
       # Ici les mois sont en UTC
-      query.group("DATE_TRUNC('month', #{query.model.name.pluralize}.created_at)")
+      "DATE_TRUNC('month', #{month_group_table(query)}.#{date_group_attribute})"
+    end
+
+    def grouped_by_month(query)
+      query.group(month_group_sql(query))
     end
 
     def grouped_by_category(query)
@@ -174,13 +188,19 @@ module Stats
       #  ...
       # ]
 
-      query.count.each_with_object({}) do |entry, hash|
+      grouped_counts(query).each_with_object({}) do |entry, hash|
         month = entry.first.first.to_datetime
         category = entry.first.second
         count = entry.second
         hash[category] ||= {}
         hash[category][month] = count
       end
+    end
+
+    def grouped_counts(query)
+      return query.count unless category_count_distinct?
+
+      query.distinct.count("#{query.table_name}.#{query.primary_key}")
     end
 
     def full_results(results)

--- a/app/services/stats/concerns/filtered_aggregates.rb
+++ b/app/services/stats/concerns/filtered_aggregates.rb
@@ -1,0 +1,50 @@
+module Stats::Concerns
+  # Buckets are not exclusive here: a row can match several `aggregate_filters` conditions.
+  # `from_others` is total minus the sum of the other buckets, so it can go negative.
+  module FilteredAggregates
+    def build_filtered_series
+      rows = indexed_aggregate_rows
+      series = aggregate_filters.keys.map do |key|
+        { name: aggregate_series_name(key), data: all_months.map { |month| rows.dig(month, key).to_i } }
+      end
+      return series unless with_others?
+
+      others = { name: aggregate_series_name(:from_others), data: all_months.map { |month| others_count(rows, month) } }
+      series.unshift(others)
+    end
+
+    def with_others?
+      false
+    end
+
+    private
+
+    def indexed_aggregate_rows
+      scope = filtered(main_query)
+      month_sql = month_group_sql(scope)
+
+      selects = [Arel.sql("#{month_sql} AS month")]
+      aggregate_filters.each { |key, condition| selects << Arel.sql("COUNT(*) FILTER (WHERE #{condition}) AS #{key}") }
+      selects << Arel.sql('COUNT(*) AS total_count') if with_others?
+
+      keys = aggregate_filters.keys
+      keys += [:total_count] if with_others?
+
+      scope.group(Arel.sql(month_sql)).pluck(*selects).each_with_object({}) do |row, hash|
+        month = row.first.to_date.beginning_of_month
+        hash[month] = keys.zip(row.drop(1)).to_h
+      end
+    end
+
+    def others_count(rows, month)
+      data = rows[month]
+      return 0 if data.blank?
+
+      data[:total_count].to_i - aggregate_filters.keys.sum { |key| data[key].to_i }
+    end
+
+    def aggregate_series_name(key)
+      I18n.t("stats.series.#{key}.title")
+    end
+  end
+end

--- a/app/services/stats/concerns/partitioned_category.rb
+++ b/app/services/stats/concerns/partitioned_category.rb
@@ -1,0 +1,22 @@
+module Stats::Concerns
+  # category_buckets is an ordered list of [key, condition_sql | :else].
+  # Must be included after Stats::BaseStats so `super` resolves to the base pipeline.
+  module PartitionedCategory
+    def category_group_attribute
+      whens = category_buckets.reject { |_, condition| condition == :else }
+        .map { |key, condition| "WHEN (#{condition}) THEN '#{key}'" }
+      else_bucket = category_buckets.find { |_, condition| condition == :else }
+      else_clause = else_bucket ? "ELSE '#{else_bucket.first}'" : ''
+      Arel.sql("CASE #{whens.join(' ')} #{else_clause} END")
+    end
+
+    # Fixed order so empty categories still appear, without an extra query.
+    def all_categories
+      category_buckets.map { |key, _| key.to_s }
+    end
+
+    def categorized_results(query)
+      super.tap { |results| results.delete(nil) }
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -169,25 +169,71 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "caeb5035f86b6b391254bf0d8d77bfb1838cf7559a4b19852a55c33bd6e32422",
+      "fingerprint": "cbc91f12993eb07a7d6ef3519044809e70299e03d77b8844457fa028c795c06d",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/services/stats/base_stats.rb",
-      "line": 154,
+      "file": "app/services/stats/concerns/partitioned_category.rb",
+      "line": 20,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "query.group(\"DATE_TRUNC('month', #{query.model.name.pluralize}.created_at)\")",
+      "code": "Arel.sql(\"CASE #{category_buckets.reject do\n (condition == :else)\n end.map do\n \"WHEN (#{condition}) THEN '#{key}'\"\n end.join(\" \")} #{(\"ELSE '#{category_buckets.find do\n (condition == :else)\n end.first}'\" or \"\")} END\")",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Stats::BaseStats",
-        "method": "grouped_by_month"
+        "class": "Stats::Concerns::PartitionedCategory",
+        "method": "category_group_attribute"
       },
-      "user_input": "query.model.name.pluralize",
-      "confidence": "Weak",
+      "user_input": "category_buckets.reject do\n (condition == :else)\n end.map do\n \"WHEN (#{condition}) THEN '#{key}'\"\n end.join(\" \")",
+      "confidence": "Medium",
       "cwe_id": [
         89
       ],
-      "note": ""
+      "note": "Raw SQL built from trusted constants (enum values, column/table names, fixed labels) — never user input"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "cea613a7f3a5f453ed42cb7efe5a77a433a43c078d6b4c4fcda5c831e90047e0",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/stats/concerns/filtered_aggregates.rb",
+      "line": 36,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"COUNT(*) FILTER (WHERE #{condition}) AS #{key}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Stats::Concerns::FilteredAggregates",
+        "method": "indexed_aggregate_rows"
+      },
+      "user_input": "condition",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Raw SQL built from trusted constants (enum values, column/table names, fixed labels) — never user input"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "edb921fbe0405e604b3f37c85f454a3e449c9a4a791f815b391d0f48ce95b72d",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/stats/concerns/filtered_aggregates.rb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"#{month_group_sql(filtered(main_query))} AS month\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Stats::Concerns::FilteredAggregates",
+        "method": "indexed_aggregate_rows"
+      },
+      "user_input": "month_group_sql(filtered(main_query))",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "Raw SQL built from trusted constants (enum values, column/table names, fixed labels) — never user input"
     },
     {
       "warning_type": "Cross-Site Scripting",

--- a/spec/models/solicitation_spec.rb
+++ b/spec/models/solicitation_spec.rb
@@ -452,6 +452,31 @@ end
     it { is_expected.to contain_exactly(solicitation) }
   end
 
+  describe '.mtm_campaign_cont_sql' do
+    let!(:from_pk_campaign) { create :solicitation, form_info: { pk_campaign: 'entreprendre-2026' } }
+    let!(:from_mtm_campaign) { create :solicitation, form_info: { mtm_campaign: 'via-entreprendre' } }
+    let!(:other) { create :solicitation, form_info: { mtm_campaign: 'googleads' } }
+
+    subject { described_class.where(described_class.mtm_campaign_cont_sql('entreprendre')) }
+
+    it 'matches the same rows as the mtm_campaign_cont scope' do
+      is_expected.to contain_exactly(from_pk_campaign, from_mtm_campaign)
+      is_expected.to match_array(described_class.mtm_campaign_cont('entreprendre'))
+    end
+  end
+
+  describe '.from_integration_sql' do
+    let!(:from_iframe) { create :solicitation, landing: create(:landing, integration: :iframe) }
+    let!(:from_intern) { create :solicitation, landing: create(:landing, integration: :intern) }
+
+    subject { described_class.where(described_class.from_integration_sql(:iframe)) }
+
+    it 'matches the same rows as the from_integration scope' do
+      is_expected.to contain_exactly(from_iframe)
+      is_expected.to match_array(described_class.from_integration(:iframe))
+    end
+  end
+
   describe '#have_landing' do
     let(:landing) { create :landing, slug: 'landing-slug' }
     let(:solicitation) { create :solicitation, landing: landing }

--- a/spec/services/stats/acquisitions/by_new_companies_spec.rb
+++ b/spec/services/stats/acquisitions/by_new_companies_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Stats::Acquisitions::ByNewCompanies, type: :model do
+  let(:params) { { start_date: '2026-01-01', end_date: '2026-01-31' } }
+  let(:graph) { described_class.new(params) }
+
+  def done_need(solicitation:, facility:, created_at:)
+    diagnosis = create(:diagnosis_completed, solicitation: solicitation, facility: facility)
+    need = diagnosis.needs.first
+    need.update_columns(created_at: created_at, status: Need.statuses[:done])
+    need
+  end
+
+  before do
+    travel_to(Time.zone.parse('2026-01-15 12:00'))
+    facility = create(:facility)
+    first_solicitation = create(:solicitation)   # min id for the facility => "new"
+    later_solicitation = create(:solicitation)   # not the first => "known"
+    done_need(solicitation: first_solicitation, facility: facility, created_at: '2026-01-10')
+    done_need(solicitation: later_solicitation, facility: facility, created_at: '2026-01-12')
+  end
+
+  it 'splits needs between known and new companies (order preserved)' do
+    expect(graph.series).to eq [
+      { name: I18n.t('stats.from_known_companies'), data: [1] },
+      { name: I18n.t('stats.from_new_companies'), data: [1] }
+    ]
+  end
+
+  it 'derives the new-companies rate and secondary count from the series' do
+    expect(graph.count).to eq '50%'
+    expect(graph.secondary_count).to eq 1
+  end
+
+  it 'computes everything in a bounded number of queries' do
+    expect(QueryCounter.count { graph.series; graph.count; graph.secondary_count }).to be <= 2
+  end
+end

--- a/spec/services/stats/acquisitions/overall_distribution_spec.rb
+++ b/spec/services/stats/acquisitions/overall_distribution_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe 'Stats::Acquisitions overall distribution', type: :model do
+  let(:params) { { start_date: '2026-01-01', end_date: '2026-02-28' } }
+  let(:line) { Stats::Acquisitions::OverallDistributionNeedsTransmitted.new(params) }
+  let(:column) { Stats::Acquisitions::OverallDistributionNeedsTransmittedColumn.new(params) }
+
+  def create_need(created_at:, integration: :intern, form_info: {})
+    landing = create(:landing, integration: integration)
+    solicitation = create(:solicitation, landing: landing, form_info: form_info)
+    diagnosis = create(:diagnosis_completed, solicitation: solicitation)
+    need = diagnosis.needs.first
+    need.update_columns(created_at: created_at)
+    need
+  end
+
+  before do
+    travel_to(Time.zone.parse('2026-02-15 12:00'))
+    # January
+    create_need(created_at: '2026-01-10', form_info: { mtm_campaign: 'entreprendre' }) # A
+    create_need(created_at: '2026-01-12', integration: :iframe) # B
+    # February
+    create_need(created_at: '2026-02-05', integration: :iframe, form_info: { mtm_campaign: 'entreprendre' }) # C overlap
+    create_need(created_at: '2026-02-07', form_info: { mtm_campaign: 'googleads' })             # D
+    create_need(created_at: '2026-02-09')                                                       # E plain / others
+  end
+
+  it 'buckets the line-chart series by acquisition source over the two months' do
+    expect(line.all_months).to eq [Date.new(2026, 1, 1), Date.new(2026, 2, 1)]
+    expect(line.series).to eq [
+      { name: 'Entreprendre', data: [1, 1] },
+      { name: 'Google Ads', data: [0, 1] },
+      { name: 'Iframes', data: [1, 1] },
+      { name: 'Redirections', data: [0, 0] },
+      { name: 'API', data: [0, 0] }
+    ]
+  end
+
+  it 'keeps the overlap semantics: from_others computed by subtraction, others first' do
+    # need C matches both Entreprendre and Iframes, so from_others (a subtraction) stays 0 despite plain need E
+    expect(column.series).to eq [
+      { name: 'Autres provenances', data: [0, 0] },
+      { name: 'Entreprendre', data: [1, 1] },
+      { name: 'Google Ads', data: [0, 1] },
+      { name: 'Iframes', data: [1, 1] },
+      { name: 'Redirections', data: [0, 0] },
+      { name: 'API', data: [0, 0] }
+    ]
+  end
+
+  it 'computes each variant with a bounded number of queries' do
+    expect(QueryCounter.count { line.series }).to be <= 2
+    expect(QueryCounter.count { column.series }).to be <= 2
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ include Pundit::Authorization
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
+  # Unlike Minitest, RSpec doesn't auto-revert travel_to, so a frozen time could leak into later examples
+  config.after { travel_back } # rubocop:disable Rails/RedundantTravelBack
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,27 @@
+# Counts real SQL queries issued inside a block, ignoring schema/transaction statements and cached queries
+class QueryCounter
+  IGNORED_STATEMENTS = /\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|SET|SHOW)/i
+  IGNORED_NAMES = %w[SCHEMA TRANSACTION].freeze
+
+  def self.count(&block)
+    counter = new
+    counter.count(&block)
+  end
+
+  def count
+    queries = 0
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      payload = args.last
+      next if payload[:cached]
+      next if IGNORED_NAMES.include?(payload[:name])
+      next if payload[:sql].to_s.match?(IGNORED_STATEMENTS)
+
+      queries += 1
+    end
+
+    yield
+    queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+end


### PR DESCRIPTION
**Premiere partie sur la page /stats/equipe/acquisition**

Les graphes "acquisitions" (répartition par source, entreprises connues vs. nouvelles) calculaient leurs séries mensuelles en Ruby, avec une requête SQL par série et par mois : jusqu'à ~30 requêtes par graphe.

Passage à une seule requête SQL agrégée par graphe, via deux nouveaux concerns :
- `FilteredAggregates` Pour le series qui puvent se chevaucher (ex: une sollicitation peu venir d'une iframe/api ou d'une campagne).
- `PartitionedCategory` : pour les séries mutuellement exclusives (ex: entreprise connue vs. nouvelle).

`NeedsScope` a été extrait de `NeedsBase` pour séparer le scope de requête de la logique de répartition par source, pour permettre à `ByNewCompanies` de réutiliser le scope sans hériter de `FilteredAggregates`.

**avant / après (cache vidé)**

7 graphiques chargés en parallèle. Temps mesuré = ActiveRecord, d'après les logs serveur.

| | Avant | Après |
|---|---|---|
| Requêtes de calcul par graphe | ~35 à 42 | 1 |
| Temps DB par graphe (médiane) | ~1,2 s | ~155 ms |
| Graphe le plus lent (`by_new_companies`) | 3,4 s | 180 ms |
| Total DB des 7 graphes | ~9,7 s | ~1,0 s |

**avant / après avec un filtre sur IDF et la thématique difficultés financieres**

Vue filtrée = jamais servie par le cache, donc recalculée à chaque recherche. 7 graphiques en parallèle, temps = ActiveRecord.

| | Avant | Après |
|---|---|---|
| Requêtes de calcul par graphe | ~35 à 42 | 1 |
| Temps DB par graphe (médiane) | ~520 ms | ~50 ms |
| Graphe le plus lent (`by_new_companies`) | 3,1 s | 140 ms |
| Total DB des 7 graphes | ~8,5 s | ~0,5 s |
