### PR TITLE
amélioration des perf des stats 2/3 : partie pilotage par besoin et partenaires

### DIFF
--- a/app/services/stats/base_stats.rb
+++ b/app/services/stats/base_stats.rb
@@ -160,8 +160,9 @@ module Stats
     private
 
     def month_group_sql(query)
-      # Ici les mois sont en UTC
-      "DATE_TRUNC('month', #{month_group_table(query)}.#{date_group_attribute})"
+      # created_at is stored in UTC, it is converted back to Paris time before being truncated
+      column = "#{month_group_table(query)}.#{date_group_attribute}"
+      "DATE_TRUNC('month', #{column} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Paris')"
     end
 
     def grouped_by_month(query)
@@ -222,7 +223,7 @@ module Stats
       all_categories_results = all_categories.index_with { |c| all_months_zero.dup }
 
       results.each do |category, month_values|
-        all_categories_results[category].merge! month_values
+        all_categories_results[category].merge!(month_values.slice(*all_months))
       end
 
       all_categories_results

--- a/app/services/stats/matches/base.rb
+++ b/app/services/stats/matches/base.rb
@@ -5,8 +5,9 @@ module Stats::Matches::Base
     Match.sent.joins(:need).where(need: needs_base_scope)
   end
 
-  def get_month_query(query, range)
-    query.joins(:need).merge(Need.created_between(range.first, range.last))
+  # Matches are grouped by their need's creation month.
+  def month_group_table(_query)
+    'needs'
   end
 
   def colors

--- a/app/services/stats/matches/done.rb
+++ b/app/services/stats/matches/done.rb
@@ -4,42 +4,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:other, :else],
+        [:done, "matches.status = '#{Match.statuses[:done]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @done_status = []
-      @other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @done_status.push(month_query.status_done.count)
-        @other_status.push(month_query.not_status_done.count)
-      end
-
-      as_series(@done_status, @other_status)
+    def category_name(key)
+      key == 'done' ? I18n.t('stats.done_status') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.matches_done.subtitle')
-    end
-
-    private
-
-    def as_series(done_status, other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: other_status
-        },
-        {
-          name: I18n.t('stats.done_status'),
-          data: done_status
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/done_no_help.rb
+++ b/app/services/stats/matches/done_no_help.rb
@@ -4,41 +4,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:other, :else],
+        [:done_no_help, "matches.status = '#{Match.statuses[:done_no_help]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @done_no_help = []
-      @other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @done_no_help.push(month_query.status_done_no_help.count)
-        @other_status.push(month_query.not_status_done_no_help.count)
-      end
-      as_series(@done_no_help, @other_status)
+    def category_name(key)
+      key == 'done_no_help' ? I18n.t('stats.done_no_help_status') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.matches_done_no_help.subtitle')
-    end
-
-    private
-
-    def as_series(done_no_help, other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: other_status
-        },
-        {
-          name: I18n.t('stats.done_no_help_status'),
-          data: done_no_help
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/done_not_reachable.rb
+++ b/app/services/stats/matches/done_not_reachable.rb
@@ -4,42 +4,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:other, :else],
+        [:done_not_reachable, "matches.status = '#{Match.statuses[:done_not_reachable]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @not_reachable_status = []
-      @other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @not_reachable_status.push(month_query.status_done_not_reachable.count)
-        @other_status.push(month_query.not_status_done_not_reachable.count)
-      end
-
-      as_series(@not_reachable_status, @other_status)
+    def category_name(key)
+      key == 'done_not_reachable' ? I18n.t('stats.not_reachable_status') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.matches_done_not_reachable.subtitle')
-    end
-
-    private
-
-    def as_series(not_reachable_status, other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: other_status
-        },
-        {
-          name: I18n.t('stats.not_reachable_status'),
-          data: not_reachable_status
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/not_for_me.rb
+++ b/app/services/stats/matches/not_for_me.rb
@@ -4,42 +4,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:other, :else],
+        [:not_for_me, "matches.status = '#{Match.statuses[:not_for_me]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @not_for_me_status = []
-      @other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @not_for_me_status.push(month_query.status_not_for_me.count)
-        @other_status.push(month_query.not_status_not_for_me.count)
-      end
-
-      as_series(@not_for_me_status, @other_status)
+    def category_name(key)
+      key == 'not_for_me' ? I18n.t('stats.not_for_me_status') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.matches_not_for_me.subtitle')
-    end
-
-    private
-
-    def as_series(not_for_me_status, other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: other_status
-        },
-        {
-          name: I18n.t('stats.not_for_me_status'),
-          data: not_for_me_status
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/not_positioning.rb
+++ b/app/services/stats/matches/not_positioning.rb
@@ -5,40 +5,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:positioning, :else],
+        [:not_positioning, "matches.status = '#{Match.statuses[:quo]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @not_positioning, @positioning = [], []
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @positioning.push(month_query.not_status_quo.count)
-        @not_positioning.push(month_query.status_quo.count)
-      end
-
-      as_series(@not_positioning, @positioning)
+    def category_name(key)
+      key == 'positioning' ? I18n.t('stats.positioning') : I18n.t('stats.not_positioning')
     end
 
     def subtitle
       I18n.t('stats.series.matches_not_positioning.subtitle')
-    end
-
-    private
-
-    def as_series(not_positioning, positioning)
-      [
-        {
-          name: I18n.t('stats.positioning'),
-          data: positioning
-        },
-        {
-          name: I18n.t('stats.not_positioning'),
-          data: not_positioning
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/positioning.rb
+++ b/app/services/stats/matches/positioning.rb
@@ -3,40 +3,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:not_positioning, "matches.status = '#{Match.statuses[:quo]}'"],
+        [:positioning, :else]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @positioning, @not_positioning = [], []
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @positioning.push(month_query.not_status_quo.count)
-        @not_positioning.push(month_query.status_quo.count)
-      end
-
-      as_series(@positioning, @not_positioning)
+    def category_name(key)
+      key == 'positioning' ? I18n.t('stats.positioning') : I18n.t('stats.not_positioning')
     end
 
     def subtitle
       I18n.t('stats.series.matches_positioning.subtitle')
-    end
-
-    private
-
-    def as_series(positioning, not_positioning)
-      [
-        {
-          name: I18n.t('stats.not_positioning'),
-          data: not_positioning
-        },
-        {
-          name: I18n.t('stats.positioning'),
-          data: positioning
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/taking_care.rb
+++ b/app/services/stats/matches/taking_care.rb
@@ -4,42 +4,21 @@ module Stats::Matches
     include ::Stats::BaseStats
     include ::Stats::TwoRatesStats
     include Stats::Matches::Base
+    include Stats::Concerns::PartitionedCategory
 
-    def main_query
-      matches_base_scope
+    def category_buckets
+      [
+        [:other, :else],
+        [:taking_care, "matches.status = '#{Match.statuses[:taking_care]}'"]
+      ]
     end
 
-    def build_series
-      query = filtered_main_query
-      @taking_care_status = []
-      @other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = get_month_query(query, range)
-        @taking_care_status.push(month_query.status_taking_care.count)
-        @other_status.push(month_query.not_status_taking_care.count)
-      end
-
-      as_series(@taking_care_status, @other_status)
+    def category_name(key)
+      key == 'taking_care' ? I18n.t('stats.taking_care_status') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.matches_taking_care.subtitle')
-    end
-
-    private
-
-    def as_series(taking_care_status, other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: other_status
-        },
-        {
-          name: I18n.t('stats.taking_care_status'),
-          data: taking_care_status
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/matches/taking_care_time.rb
+++ b/app/services/stats/matches/taking_care_time.rb
@@ -5,7 +5,8 @@ module Stats::Matches::TakingCareTime
   include Stats::Concerns::PartitionedCategory
 
   def main_query
-    matches_base_scope.with_exchange
+    # We group by the month of the match, so we also need to limit its created_at
+    matches_base_scope.with_exchange.created_between(start_date, end_date)
   end
 
   def number_of_days

--- a/app/services/stats/matches/taking_care_time.rb
+++ b/app/services/stats/matches/taking_care_time.rb
@@ -2,6 +2,7 @@ module Stats::Matches::TakingCareTime
   include ::Stats::BaseStats
   include ::Stats::TwoRatesStats
   include Stats::Matches::Base
+  include Stats::Concerns::PartitionedCategory
 
   def main_query
     matches_base_scope.with_exchange
@@ -11,38 +12,21 @@ module Stats::Matches::TakingCareTime
     @number_of_days ||= 5
   end
 
-  def build_series
-    query = filtered_main_query
-
-    @taken_care_before = []
-    @taken_care_after = []
-
-    search_range_by_month.each do |range|
-      month_query = query.created_between(range.first, range.last)
-      @taken_care_before.push(month_query.taken_care_before(number_of_days).count)
-      @taken_care_after.push(month_query.taken_care_after(number_of_days).count)
-    end
-
-    as_series(@taken_care_before, @taken_care_after)
+  # This graph buckets by the match's own creation month.
+  def month_group_table(_query)
+    'matches'
   end
 
-  def count
-    series
-    @count ||= percentage_two_numbers(@taken_care_before, @taken_care_after)
-  end
-
-  private
-
-  def as_series(taken_care_before, taken_care_after)
+  # No :else: matches with a NULL taken_care_of_at fall out of both buckets.
+  def category_buckets
+    gap = "ABS(DATE_PART('day', matches.taken_care_of_at - matches.sent_at))"
     [
-      {
-        name: taken_care_after_label,
-          data: taken_care_after
-      },
-      {
-        name: taken_care_before_label,
-          data: taken_care_before
-      }
+      [:after, "NOT (#{gap} < #{number_of_days})"],
+      [:before, "#{gap} < #{number_of_days}"]
     ]
+  end
+
+  def category_name(key)
+    key == 'before' ? taken_care_before_label : taken_care_after_label
   end
 end

--- a/app/services/stats/needs/abandoned_total_count.rb
+++ b/app/services/stats/needs/abandoned_total_count.rb
@@ -1,47 +1,36 @@
 module Stats::Needs
   class AbandonedTotalCount
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
     def main_query
       needs_base_scope
     end
 
-    def build_series
-      @abandoned_needs = []
-      @not_abandoned_needs = []
-
-      search_range_by_month.each do |range|
-        @abandoned_needs << filtered_main_query.created_between(range.first, range.last).with_action(:abandon).count
-        @not_abandoned_needs << filtered_main_query.created_between(range.first, range.last).without_action(:abandon).count
-      end
-
-      as_series(@abandoned_needs, @not_abandoned_needs)
+    # EXISTS counts at the need level despite the reminders_actions fan-out.
+    def category_buckets
+      abandoned = <<~SQL.squish
+        EXISTS (SELECT 1 FROM reminders_actions ra
+                WHERE ra.need_id = needs.id AND ra.category = #{RemindersAction.categories[:abandon]})
+      SQL
+      [
+        [:other_needs, :else],
+        [:abandoned_needs, abandoned]
+      ]
     end
 
-    def count
-      series
-      percentage_two_numbers(@abandoned_needs, @not_abandoned_needs)
+    def category_name(key)
+      I18n.t("stats.series.needs_abandoned_total_count.#{key}")
     end
 
+    # Secondary count is the total number of needs, not the abandoned sum.
     def secondary_count
       @secondary_count ||= filtered_main_query.size
     end
 
     def subtitle
       I18n.t('stats.series.needs_abandoned_total_count.subtitle')
-    end
-
-    def as_series(abandoned_needs, not_abandoned_needs)
-      [
-        {
-          name: I18n.t('stats.series.needs_abandoned_total_count.other_needs'),
-          data: not_abandoned_needs
-        },
-        {
-          name: I18n.t('stats.series.needs_abandoned_total_count.abandoned_needs'),
-          data: abandoned_needs
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/needs/abandoned_total_count.rb
+++ b/app/services/stats/needs/abandoned_total_count.rb
@@ -8,7 +8,6 @@ module Stats::Needs
       needs_base_scope
     end
 
-    # EXISTS counts at the need level despite the reminders_actions fan-out.
     def category_buckets
       abandoned = <<~SQL.squish
         EXISTS (SELECT 1 FROM reminders_actions ra

--- a/app/services/stats/needs/concerns/response_time.rb
+++ b/app/services/stats/needs/concerns/response_time.rb
@@ -17,15 +17,10 @@ module Stats::Needs::Concerns::ResponseTime
 
   # A need is "before" if it has an exchange match handled within number_of_days.
   def category_buckets
-    exists = <<~SQL.squish
-      EXISTS (SELECT 1 FROM matches m
-              WHERE m.need_id = needs.id
-                AND m.status IN (#{exchange_match_statuses})
-                AND ABS(DATE_PART('day', m.taken_care_of_at - m.sent_at)) < #{number_of_days})
-    SQL
+    gap = "ABS(DATE_PART('day', matches.taken_care_of_at - matches.sent_at))"
     [
-      [:after, :else],
-      [:before, exists]
+      [:after, "NOT EXISTS (#{quick_match_exists_sql('gm')})"],
+      [:before, "matches.status IN (#{quick_statuses}) AND #{gap} < #{number_of_days}"]
     ]
   end
 
@@ -39,7 +34,15 @@ module Stats::Needs::Concerns::ResponseTime
 
   private
 
-  def exchange_match_statuses
+  def quick_statuses
     [Match.statuses[:done], Match.statuses[:done_no_help]].map { |status| "'#{status}'" }.join(', ')
+  end
+
+  def quick_match_exists_sql(alias_name)
+    <<~SQL.squish
+      SELECT 1 FROM matches #{alias_name}
+      WHERE #{alias_name}.need_id = needs.id AND #{alias_name}.status IN (#{quick_statuses})
+        AND ABS(DATE_PART('day', #{alias_name}.taken_care_of_at - #{alias_name}.sent_at)) < #{number_of_days}
+    SQL
   end
 end

--- a/app/services/stats/needs/concerns/response_time.rb
+++ b/app/services/stats/needs/concerns/response_time.rb
@@ -1,43 +1,45 @@
 module Stats::Needs::Concerns::ResponseTime
   include ::Stats::BaseStats
+  include Stats::Concerns::PartitionedCategory
 
   def base_scope
     Need.joins(:matches).where(created_at: @start_date..@end_date)
   end
 
-  def build_series
-    query = main_query
-    query = Stats::Filters::Needs.new(query, self).call
+  def filtered(query)
+    Stats::Filters::Needs.new(query, self).call
+  end
 
-    @taken_care_before = []
-    @taken_care_after = []
+  # Count at the need level despite the matches join fan-out.
+  def category_count_distinct?
+    true
+  end
 
-    search_range_by_month.each do |range|
-      month_query = query.created_between(range.first, range.last)
-      @taken_care_before.push(month_query.taken_care_before(number_of_days).count)
-      @taken_care_after.push(month_query.taken_care_after(number_of_days).count)
-    end
+  # A need is "before" if it has an exchange match handled within number_of_days.
+  def category_buckets
+    exists = <<~SQL.squish
+      EXISTS (SELECT 1 FROM matches m
+              WHERE m.need_id = needs.id
+                AND m.status IN (#{exchange_match_statuses})
+                AND ABS(DATE_PART('day', m.taken_care_of_at - m.sent_at)) < #{number_of_days})
+    SQL
+    [
+      [:after, :else],
+      [:before, exists]
+    ]
+  end
 
-    as_series(@taken_care_before, @taken_care_after)
+  def category_name(key)
+    key == 'before' ? taken_care_before_label : taken_care_after_label
   end
 
   def count
-    series
-    @count ||= percentage_two_numbers(@taken_care_before, @taken_care_after)
+    @count ||= percentage_two_numbers(series[1][:data], series[0][:data])
   end
 
   private
 
-  def as_series(taken_care_before, taken_care_after)
-    [
-      {
-        name: taken_care_after_label,
-          data: taken_care_after
-      },
-      {
-        name: taken_care_before_label,
-          data: taken_care_before
-      }
-    ]
+  def exchange_match_statuses
+    [Match.statuses[:done], Match.statuses[:done_no_help]].map { |status| "'#{status}'" }.join(', ')
   end
 end

--- a/app/services/stats/needs/done.rb
+++ b/app/services/stats/needs/done.rb
@@ -1,50 +1,22 @@
 module Stats::Needs
   class Done
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = filtered_main_query
-
-      @needs_done = []
-      @needs_other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        needs_done_query = month_query.where(status: :done)
-        needs_other_status_query = month_query.where.not(status: :done)
-        @needs_done.push(needs_done_query.count)
-        @needs_other_status.push(needs_other_status_query.count)
-      end
-
-      as_series(@needs_done, @needs_other_status)
+    def category_buckets
+      [
+        [:other, :else],
+        [:done, "needs.status = '#{Need.statuses[:done]}'"]
+      ]
     end
 
-    def count
-      build_series
-      percentage_two_numbers(@needs_done, @needs_other_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_done.size
+    def category_name(key)
+      key == 'done' ? I18n.t('stats.status_done') : I18n.t('stats.other_status')
     end
 
     def subtitle
       I18n.t('stats.series.needs_done.subtitle')
-    end
-
-    private
-
-    def as_series(needs_done, needs_other_status)
-      [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_other_status
-        },
-        {
-          name: I18n.t('stats.status_done'),
-          data: needs_done
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/needs/done_no_help.rb
+++ b/app/services/stats/needs/done_no_help.rb
@@ -1,55 +1,18 @@
 module Stats::Needs
   class DoneNoHelp
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = main_query
-      query = Stats::Filters::Needs.new(query, self).call
-
-      @needs_done_no_help = []
-      @needs_others_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        done_no_help_query = month_query.where(status: :done_no_help)
-        others_status_query = month_query.where.not(status: :done_no_help)
-        @needs_done_no_help.push(done_no_help_query.count)
-        @needs_others_status.push(others_status_query.count)
-      end
-
-      as_series(@needs_done_no_help, @needs_others_status)
-    end
-
-    def with_help(query)
-      query.where(status: :done_no_help).group_by_month(&:created_at).map { |_, v| v.size }
-    end
-
-    def without_help(query)
-      query.where.not(status: :done_no_help).group_by_month(&:created_at).map { |_, v| v.size }
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_done_no_help, @needs_others_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_done_no_help.size
-    end
-
-    private
-
-    def as_series(needs_with_help, needs_without_help)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_without_help
-        },
-        {
-          name: I18n.t('stats.status_done_no_help'),
-          data: needs_with_help
-        }
+        [:other, :else],
+        [:done_no_help, "needs.status = '#{Need.statuses[:done_no_help]}'"]
       ]
+    end
+
+    def category_name(key)
+      key == 'done_no_help' ? I18n.t('stats.status_done_no_help') : I18n.t('stats.other_status')
     end
   end
 end

--- a/app/services/stats/needs/done_not_reachable.rb
+++ b/app/services/stats/needs/done_not_reachable.rb
@@ -1,47 +1,18 @@
 module Stats::Needs
   class DoneNotReachable
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = main_query
-      query = Stats::Filters::Needs.new(query, self).call
-
-      @needs_done_not_reachable = []
-      @needs_other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        done_not_reachable_query = month_query.where(status: :done_not_reachable)
-        other_status_query = month_query.where.not(status: :done_not_reachable)
-        @needs_done_not_reachable.push(done_not_reachable_query.count)
-        @needs_other_status.push(other_status_query.count)
-      end
-
-      as_series(@needs_done_not_reachable, @needs_other_status)
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_done_not_reachable, @needs_other_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_done_not_reachable.size
-    end
-
-    private
-
-    def as_series(needs_done_not_reachable, needs_other_status)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_other_status
-        },
-        {
-          name: I18n.t('stats.status_done_not_reachable'),
-          data: needs_done_not_reachable
-        }
+        [:other, :else],
+        [:done_not_reachable, "needs.status = '#{Need.statuses[:done_not_reachable]}'"]
       ]
+    end
+
+    def category_name(key)
+      key == 'done_not_reachable' ? I18n.t('stats.status_done_not_reachable') : I18n.t('stats.other_status')
     end
   end
 end

--- a/app/services/stats/needs/exchange_with_expert.rb
+++ b/app/services/stats/needs/exchange_with_expert.rb
@@ -1,6 +1,8 @@
 module Stats::Needs
   class ExchangeWithExpert
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
     def main_query
       # This stat is available since 2020-09-01
@@ -8,47 +10,30 @@ module Stats::Needs
         .where(created_at: Time.zone.local(2020, 9, 1)..)
     end
 
-    def build_series
-      query = filtered_main_query
+    def category_buckets
+      without = [
+        Need.statuses[:not_for_me], Need.statuses[:done_not_reachable],
+        Need.statuses[:quo], Need.statuses[:taking_care]
+      ]
+      with = [Need.statuses[:done], Need.statuses[:done_no_help]]
+      [
+        [:without_exchange, status_in(without)],
+        [:with_exchange, status_in(with)]
+      ]
+    end
 
-      @needs_with_exchange = []
-      @needs_without_exchange = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        @needs_with_exchange.push(month_query.with_exchange.count)
-        @needs_without_exchange.push(month_query.without_exchange.count)
-      end
-
-      as_series(@needs_with_exchange, @needs_without_exchange)
+    def category_name(key)
+      I18n.t("stats.series.needs_exchange_with_expert.#{key}")
     end
 
     def subtitle
       nil
     end
 
-    def count
-      series
-      percentage_two_numbers(@needs_with_exchange, @needs_without_exchange)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.with_exchange.size
-    end
-
     private
 
-    def as_series(needs_with_exchange, needs_without_exchange)
-      [
-        {
-          name: I18n.t('stats.series.needs_exchange_with_expert.without_exchange'),
-          data: needs_without_exchange
-        },
-        {
-          name: I18n.t('stats.series.needs_exchange_with_expert.with_exchange'),
-          data: needs_with_exchange
-        }
-      ]
+    def status_in(statuses)
+      "needs.status IN (#{statuses.map { |status| "'#{status}'" }.join(', ')})"
     end
   end
 end

--- a/app/services/stats/needs/not_for_me.rb
+++ b/app/services/stats/needs/not_for_me.rb
@@ -1,47 +1,18 @@
 module Stats::Needs
   class NotForMe
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = main_query
-      query = Stats::Filters::Needs.new(query, self).call
-
-      @needs_not_for_me = []
-      @needs_other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        not_for_me_query = month_query.where(status: :not_for_me)
-        other_status_query = month_query.where.not(status: :not_for_me)
-        @needs_not_for_me.push(not_for_me_query.count)
-        @needs_other_status.push(other_status_query.count)
-      end
-
-      as_series(@needs_not_for_me, @needs_other_status)
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_not_for_me, @needs_other_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_not_for_me.size
-    end
-
-    private
-
-    def as_series(needs_not_for_me, needs_others_status)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_others_status
-        },
-        {
-          name: I18n.t('stats.status_not_for_me'),
-          data: needs_not_for_me
-        }
+        [:other, :else],
+        [:not_for_me, "needs.status = '#{Need.statuses[:not_for_me]}'"]
       ]
+    end
+
+    def category_name(key)
+      key == 'not_for_me' ? I18n.t('stats.status_not_for_me') : I18n.t('stats.other_status')
     end
   end
 end

--- a/app/services/stats/needs/positioning.rb
+++ b/app/services/stats/needs/positioning.rb
@@ -2,40 +2,21 @@ module Stats::Needs
   class Positioning
     include Stats::Needs::Base
     include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = filtered_main_query
-      @positioning, @not_positioning = [], []
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        @positioning.push(month_query.not_status_quo.count)
-        @not_positioning.push(month_query.status_quo.count)
-      end
+    def category_buckets
+      [
+        [:not_positioning, "needs.status = '#{Need.statuses[:quo]}'"],
+        [:positioning, :else]
+      ]
+    end
 
-      as_series(@positioning, @not_positioning)
+    def category_name(key)
+      key == 'positioning' ? I18n.t('stats.positioning') : I18n.t('stats.not_positioning')
     end
 
     def subtitle
       I18n.t('stats.series.needs_positioning.subtitle')
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.not_status_quo.size
-    end
-
-    private
-
-    def as_series(positioning, not_positioning)
-      [
-        {
-          name: I18n.t('stats.not_positioning'),
-          data: not_positioning
-        },
-        {
-          name: I18n.t('stats.positioning'),
-          data: positioning
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/needs/quo.rb
+++ b/app/services/stats/needs/quo.rb
@@ -1,46 +1,18 @@
 module Stats::Needs
   class Quo
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = filtered_main_query
-
-      @needs_quo = []
-      @needs_other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        needs_quo_query = month_query.where(status: :quo)
-        needs_other_status_query = month_query.where.not(status: :quo)
-        @needs_quo.push(needs_quo_query.count)
-        @needs_other_status.push(needs_other_status_query.count)
-      end
-
-      as_series(@needs_quo, @needs_other_status)
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_quo, @needs_other_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_quo.size
-    end
-
-    private
-
-    def as_series(needs_quo, needs_other_status)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_other_status
-        },
-        {
-          name: I18n.t('stats.status_quo'),
-          data: needs_quo
-        }
+        [:other, :else],
+        [:quo, "needs.status = '#{Need.statuses[:quo]}'"]
       ]
+    end
+
+    def category_name(key)
+      key == 'quo' ? I18n.t('stats.status_quo') : I18n.t('stats.other_status')
     end
   end
 end

--- a/app/services/stats/needs/requalification.rb
+++ b/app/services/stats/needs/requalification.rb
@@ -1,54 +1,30 @@
 module Stats::Needs
   class Requalification
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
     def main_query
       # This stat is available since 2020-09-01
       needs_base_scope
         .where(created_at: Time.zone.local(2020, 9, 1)..)
+        .joins(diagnosis: { solicitation: :landing_subject })
     end
 
-    def build_series
-      query = filtered_main_query
+    # No :else: needs without a comparable landing_subject fall out of both buckets.
+    def category_buckets
+      [
+        [:not_requalified, 'needs.subject_id = landing_subjects.subject_id'],
+        [:requalified, 'needs.subject_id != landing_subjects.subject_id']
+      ]
+    end
 
-      @needs_requalified = []
-      @needs_not_requalified = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        @needs_requalified.push(month_query.requalified.count)
-        @needs_not_requalified.push(month_query.not_requalified.count)
-      end
-
-      as_series(@needs_requalified, @needs_not_requalified)
+    def category_name(key)
+      I18n.t("stats.series.needs_requalification.#{key}")
     end
 
     def subtitle
       nil
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_requalified, @needs_not_requalified)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.requalified.size
-    end
-
-    private
-
-    def as_series(needs_requalified, needs_not_requalified)
-      [
-        {
-          name: I18n.t('stats.series.needs_requalification.not_requalified'),
-          data: needs_not_requalified
-        },
-        {
-          name: I18n.t('stats.series.needs_requalification.requalified'),
-          data: needs_requalified
-        }
-      ]
     end
   end
 end

--- a/app/services/stats/needs/taking_care.rb
+++ b/app/services/stats/needs/taking_care.rb
@@ -1,46 +1,18 @@
 module Stats::Needs
   class TakingCare
     include Stats::Needs::Base
+    include ::Stats::TwoRatesStats
+    include Stats::Concerns::PartitionedCategory
 
-    def build_series
-      query = filtered_main_query
-
-      @needs_taking_care = []
-      @needs_other_status = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        needs_taking_care_query = month_query.where(status: :taking_care)
-        needs_other_status_query = month_query.where.not(status: :taking_care)
-        @needs_taking_care.push(needs_taking_care_query.count)
-        @needs_other_status.push(needs_other_status_query.count)
-      end
-
-      as_series(@needs_taking_care, @needs_other_status)
-    end
-
-    def count
-      series
-      percentage_two_numbers(@needs_taking_care, @needs_other_status)
-    end
-
-    def secondary_count
-      @secondary_count ||= filtered_main_query.status_taking_care.size
-    end
-
-    private
-
-    def as_series(needs_taking_care, needs_other_status)
+    def category_buckets
       [
-        {
-          name: I18n.t('stats.other_status'),
-          data: needs_other_status
-        },
-        {
-          name: I18n.t('stats.status_taking_care'),
-          data: needs_taking_care
-        }
+        [:other, :else],
+        [:taking_care, "needs.status = '#{Need.statuses[:taking_care]}'"]
       ]
+    end
+
+    def category_name(key)
+      key == 'taking_care' ? I18n.t('stats.status_taking_care') : I18n.t('stats.other_status')
     end
   end
 end

--- a/app/services/stats/needs/transmitted.rb
+++ b/app/services/stats/needs/transmitted.rb
@@ -8,16 +8,9 @@ module Stats::Needs
     end
 
     def build_series
-      query = filtered(main_query)
-
-      @needs = []
-
-      search_range_by_month.each do |range|
-        month_query = query.created_between(range.first, range.last)
-        @needs.push(month_query.distinct.count)
-      end
-
-      as_series(@needs)
+      counts = grouped_by_month(filtered(main_query)).distinct.count(:id)
+      by_month = counts.transform_keys { |month| month.to_date.beginning_of_month }
+      [{ name: I18n.t('stats.series.transmitted_needs.title'), data: all_months.map { |month| by_month[month] || 0 } }]
     end
 
     def chart
@@ -29,18 +22,7 @@ module Stats::Needs
     end
 
     def format
-      '{series.name} : <b>{point.y}</b>'
-    end
-
-    private
-
-    def as_series(needs)
-      [
-        {
-          name: I18n.t('stats.series.transmitted_needs.title'),
-          data: needs
-        }
-      ]
+      '{series.name} : <b>{point.y}</b>'
     end
   end
 end

--- a/spec/services/stats/matches/two_rates_characterization_spec.rb
+++ b/spec/services/stats/matches/two_rates_characterization_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+# Golden values for the matches two-rate graphs: bucketed by match status,
+# grouped by the need's created_at month.
+describe 'Stats::Matches two-rate graphs', type: :model do
+  let(:params) { { start_date: '2026-01-01', end_date: '2026-02-28' } }
+
+  before do
+    travel_to(Time.zone.parse('2026-02-15 12:00'))
+    rows = {
+      done: '2026-01-10', quo: '2026-01-11', taking_care: '2026-01-12',
+      done_no_help: '2026-02-05', done_not_reachable: '2026-02-06', not_for_me: '2026-02-07'
+    }.map do |status, created_at|
+      need = create(:diagnosis_completed).needs.first
+      [need, need.matches.first, status, created_at]
+    end
+    rows.each do |need, match, status, created_at|
+      match.update_columns(status: status)
+      need.update_columns(created_at: created_at)
+    end
+  end
+
+  def graph(klass)
+    "Stats::Matches::#{klass}".constantize.new(params)
+  end
+
+  {
+    'Done' => ['stats.done_status', [2, 3], [1, 0], '17%', 1],
+    'DoneNoHelp' => ['stats.done_no_help_status', [3, 2], [0, 1], '17%', 1],
+    'DoneNotReachable' => ['stats.not_reachable_status', [3, 2], [0, 1], '17%', 1],
+    'NotForMe' => ['stats.not_for_me_status', [3, 2], [0, 1], '17%', 1],
+    'TakingCare' => ['stats.taking_care_status', [2, 3], [1, 0], '17%', 1]
+  }.each do |klass, (target_key, other_data, target_data, count, secondary)|
+    it "#{klass} keeps its status split, rate and secondary count" do
+      g = graph(klass)
+      expect(g.series).to eq [
+        { name: I18n.t('stats.other_status'), data: other_data },
+        { name: I18n.t(target_key), data: target_data }
+      ]
+      expect(g.count).to eq count
+      expect(g.secondary_count).to eq secondary
+    end
+  end
+
+  it 'Positioning keeps non-quo as the positioning bucket' do
+    g = graph('Positioning')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.not_positioning'), data: [1, 0] },
+      { name: I18n.t('stats.positioning'), data: [2, 3] }
+    ]
+    expect(g.count).to eq '83%'
+    expect(g.secondary_count).to eq 5
+  end
+
+  it 'NotPositioning mirrors Positioning with quo as target' do
+    g = graph('NotPositioning')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.positioning'), data: [2, 3] },
+      { name: I18n.t('stats.not_positioning'), data: [1, 0] }
+    ]
+    expect(g.count).to eq '17%'
+    expect(g.secondary_count).to eq 1
+  end
+
+  it 'computes each graph in a bounded number of queries' do
+    %w[Done DoneNoHelp DoneNotReachable NotForMe TakingCare Positioning NotPositioning].each do |klass|
+      g = graph(klass)
+      queries = QueryCounter.count { g.series; g.count; g.secondary_count }
+      expect(queries).to be <= 3, "#{klass} issued #{queries} queries"
+    end
+  end
+end

--- a/spec/services/stats/needs/two_rates_characterization_spec.rb
+++ b/spec/services/stats/needs/two_rates_characterization_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+# Golden values for the needs two-rate graphs (series, count, secondary_count),
+# so the single-query refactor stays behaviour-preserving.
+describe 'Stats::Needs two-rate graphs', type: :model do
+  let(:params) { { start_date: '2026-01-01', end_date: '2026-02-28' } }
+
+  before do
+    travel_to(Time.zone.parse('2026-02-15 12:00'))
+    needs = {
+      done: '2026-01-10', quo: '2026-01-11', taking_care: '2026-01-12',
+      done_no_help: '2026-02-05', done_not_reachable: '2026-02-06', not_for_me: '2026-02-07'
+    }.map do |status, created_at|
+      [create(:diagnosis_completed).needs.first, status, created_at]
+    end
+    create(:reminders_action, need: needs.first.first, category: :abandon)
+    # Set statuses LAST so no callback/touch resets them.
+    needs.each { |need, status, created_at| need.update_columns(status: status, created_at: created_at) }
+  end
+
+  def graph(klass)
+    "Stats::Needs::#{klass}".constantize.new(params)
+  end
+
+  {
+    'Done' => ['stats.status_done', [2, 3], [1, 0], '17%', 1],
+    'Quo' => ['stats.status_quo', [2, 3], [1, 0], '17%', 1],
+    'TakingCare' => ['stats.status_taking_care', [2, 3], [1, 0], '17%', 1],
+    'DoneNoHelp' => ['stats.status_done_no_help', [3, 2], [0, 1], '17%', 1],
+    'DoneNotReachable' => ['stats.status_done_not_reachable', [3, 2], [0, 1], '17%', 1],
+    'NotForMe' => ['stats.status_not_for_me', [3, 2], [0, 1], '17%', 1]
+  }.each do |klass, (target_key, other_data, target_data, count, secondary)|
+    it "#{klass} keeps its status split, rate and secondary count" do
+      g = graph(klass)
+      expect(g.series).to eq [
+        { name: I18n.t('stats.other_status'), data: other_data },
+        { name: I18n.t(target_key), data: target_data }
+      ]
+      expect(g.count).to eq count
+      expect(g.secondary_count).to eq secondary
+    end
+  end
+
+  it 'Positioning keeps quo vs non-quo split' do
+    g = graph('Positioning')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.not_positioning'), data: [1, 0] },
+      { name: I18n.t('stats.positioning'), data: [2, 3] }
+    ]
+    expect(g.count).to eq '83%'
+    expect(g.secondary_count).to eq 5
+  end
+
+  it 'ExchangeWithExpert splits by exchange statuses' do
+    g = graph('ExchangeWithExpert')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.series.needs_exchange_with_expert.without_exchange'), data: [2, 2] },
+      { name: I18n.t('stats.series.needs_exchange_with_expert.with_exchange'), data: [1, 1] }
+    ]
+    expect(g.count).to eq '33%'
+    expect(g.secondary_count).to eq 2
+  end
+
+  it 'Requalification keeps the empty not-requalified bucket' do
+    g = graph('Requalification')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.series.needs_requalification.not_requalified'), data: [0, 0] },
+      { name: I18n.t('stats.series.needs_requalification.requalified'), data: [3, 3] }
+    ]
+    expect(g.count).to eq '100%'
+    expect(g.secondary_count).to eq 6
+  end
+
+  it 'AbandonedTotalCount counts abandoned needs, secondary is the total' do
+    g = graph('AbandonedTotalCount')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.series.needs_abandoned_total_count.other_needs'), data: [2, 3] },
+      { name: I18n.t('stats.series.needs_abandoned_total_count.abandoned_needs'), data: [1, 0] }
+    ]
+    expect(g.count).to eq '17%'
+    expect(g.secondary_count).to eq 6
+  end
+
+  it 'Transmitted is a single distinct-count series' do
+    g = graph('Transmitted')
+    expect(g.series).to eq [
+      { name: I18n.t('stats.series.transmitted_needs.title'), data: [3, 3] }
+    ]
+    expect(g.count).to eq 6
+    expect(g.secondary_count).to be_nil
+  end
+
+  it 'computes each graph in a bounded number of queries' do
+    %w[
+      Done Quo TakingCare DoneNoHelp DoneNotReachable NotForMe Positioning
+      ExchangeWithExpert Requalification AbandonedTotalCount Transmitted
+    ].each do |klass|
+      g = graph(klass)
+      queries = QueryCounter.count { g.series; g.count; g.secondary_count }
+      expect(queries).to be <= 3, "#{klass} issued #{queries} queries"
+    end
+  end
+end

--- a/spec/services/stats/response_time_characterization_spec.rb
+++ b/spec/services/stats/response_time_characterization_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+# Golden values for the response-time graphs (needs and matches variants), which
+# split on the day gap between sent_at and taken_care_of_at.
+describe 'Response-time graphs', type: :model do
+  let(:params) { { start_date: '2026-01-01', end_date: '2026-02-28' } }
+
+  before do
+    travel_to(Time.zone.parse('2026-02-15 12:00'))
+    [
+      ['done', 'done', '2026-01-10 09:00', '2026-01-11 09:00', '2026-01-10'],          # gap 1 day
+      ['done', 'done_no_help', '2026-01-11 09:00', '2026-01-15 09:00', '2026-01-11'],  # gap 4 days
+      ['done', 'done', '2026-02-05 09:00', '2026-02-20 09:00', '2026-02-05']           # gap 15 days
+    ].each do |need_status, match_status, sent_at, taken_care_of_at, created_at|
+      need = create(:diagnosis_completed).needs.first
+      match = need.matches.first
+      match.update_columns(status: match_status, sent_at: sent_at, taken_care_of_at: taken_care_of_at)
+      need.update_columns(status: need_status, created_at: created_at)
+    end
+  end
+
+  def after_before(scope, before_data, after_data)
+    [
+      { name: I18n.t("stats.#{scope}.taken_care_after"), data: after_data },
+      { name: I18n.t("stats.#{scope}.taken_care_before"), data: before_data }
+    ]
+  end
+
+  it 'Needs::TakenCareInThreeDays buckets needs by their own month' do
+    g = Stats::Needs::TakenCareInThreeDays.new(params)
+    expect(g.series).to eq after_before('taken_care_in_three_days', [1, 0], [1, 1])
+    expect(g.count).to eq '33%'
+    expect(g.secondary_count).to be_nil
+  end
+
+  it 'Needs::TakenCareInFiveDays widens the gap' do
+    g = Stats::Needs::TakenCareInFiveDays.new(params)
+    expect(g.series).to eq after_before('taken_care_in_five_days', [2, 0], [0, 1])
+    expect(g.count).to eq '67%'
+    expect(g.secondary_count).to be_nil
+  end
+
+  it 'Needs::HelpedInFiveDays restricts to done needs' do
+    g = Stats::Needs::HelpedInFiveDays.new(params)
+    expect(g.series).to eq after_before('taken_care_in_five_days', [2, 0], [0, 1])
+    expect(g.count).to eq '67%'
+    expect(g.secondary_count).to be_nil
+  end
+
+  it 'Matches::TakenCareInThreeDays buckets matches by their own month' do
+    g = Stats::Matches::TakenCareInThreeDays.new(params)
+    expect(g.series).to eq after_before('taken_care_in_three_days', [0, 1], [0, 2])
+    expect(g.count).to eq '33%'
+    expect(g.secondary_count).to eq 1
+  end
+
+  it 'Matches::TakenCareInFiveDays widens the gap' do
+    g = Stats::Matches::TakenCareInFiveDays.new(params)
+    expect(g.series).to eq after_before('taken_care_in_five_days', [0, 2], [0, 1])
+    expect(g.count).to eq '67%'
+    expect(g.secondary_count).to eq 2
+  end
+
+  it 'computes each graph in a bounded number of queries' do
+    [
+      Stats::Needs::TakenCareInThreeDays, Stats::Needs::TakenCareInFiveDays, Stats::Needs::HelpedInFiveDays,
+      Stats::Matches::TakenCareInThreeDays, Stats::Matches::TakenCareInFiveDays
+    ].each do |klass|
+      g = klass.new(params)
+      queries = QueryCounter.count { g.series; g.count; g.secondary_count }
+      expect(queries).to be <= 3, "#{klass} issued #{queries} queries"
+    end
+  end
+end


### PR DESCRIPTION
suite de #4667, cette fois sur les pages stats pilotage par besoin et pilotage par partenaire


**Test de perf sur la page /stats/equipe/mises-en-relation avec comme filtre institution la CCI** :

### Chargement de la page principale

| | Avant | Après |
|---|---|---|
| Temps total | 1170ms | 412ms |
| ActiveRecord | 942,3ms (44 requêtes, 5 cached) | 279,6ms (44 requêtes, 5 cached) |

### Les 14 graphiques AJAX (`load_data?chart_name=...`)

| | Avant | Après |
|---|---|---|
| ActiveRecord cumulé | **10 015,5 ms** | **1 656,9 ms** |
| Requêtes SQL cumulées | **239** | **116** |

**Réduction d'environ 83% du temps ActiveRecord cumulé** et **~51% du nombre de requêtes** sur l'ensemble des graphiques.

