### PR TITLE
Get rid of SoftDeletable::ActiveAdminResourceController

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -4,7 +4,6 @@ ActiveAdmin.register Antenne do
   include OnDemandActivityReports
 
   controller do
-    include SoftDeletable::ActiveAdminResourceController
     include TerritorialZonesSearchable
 
     helper ActiveAdminUtilitiesHelper

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -2,7 +2,6 @@ ActiveAdmin.register Expert do
   menu priority: 4
 
   controller do
-    include SoftDeletable::ActiveAdminResourceController
     include DynamicallyFiltrable
 
     helper ActiveAdminUtilitiesHelper

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -2,7 +2,6 @@ ActiveAdmin.register Institution do
   menu parent: :experts, priority: 2
 
   controller do
-    include SoftDeletable::ActiveAdminResourceController
     include DynamicallyFiltrable
 
     helper ActiveAdminUtilitiesHelper

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -2,8 +2,6 @@ ActiveAdmin.register User do
   menu priority: 3
 
   controller do
-    include SoftDeletable::ActiveAdminResourceController
-
     def scoped_collection
       base_includes = [:antenne, :institution, :experts, :activity_matches, :experts_with_subjects, :feedbacks]
       additional_includes = []

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -29,13 +29,4 @@ module SoftDeletable
       phone_number: nil
     }
   end
-
-  module ActiveAdminResourceController
-    # Override methods from ActiveAdmin::ResourceController::DataAccess
-
-    def find_resource
-      # … however, if accessing directly the object, we like to see it even if it is soft-deleted.
-      resource_class.all.send method_for_find, params[:id]
-    end
-  end
 end


### PR DESCRIPTION
We don't need to override #find_resource. As can be guessed by the the partial comment, it’s a remnant of an already removed behaviour.

It was needed originally (in #1214 / 3f1480bc758c55e2b30e7859fed6eb3754e96e37) because we used to override #scoped_collection for all the controllers that included soft_deletable so that the deleted objects would not be visible in the collections. This was removed in #1846 / a7dbf8971476fcda061e13d9fc0ef634b322c4f2 .

Note: This was revealed by Archspec (https://archspecrb.dev), that complained about using `params` in a model class.