### PR TITLE
Tweak emphasis subjects margins

### DIFF
--- a/app/assets/stylesheets/pages/home.sass
+++ b/app/assets/stylesheets/pages/home.sass
@@ -39,8 +39,18 @@
       border-color: base.$emphasis-border-hover
     &:active, a:active
       background-color: base.$emphasis-background-active
+    .fr-notice__body
+      align-items: center
+    .fr-notice__desc, .fr-notice__title
+      display: block
     .fr-notice__link
+      background: none
+      border: 1px solid base.$emphasis-border
       white-space: nowrap
+      padding: .5rem 1rem
+      min-height: 2.5rem
+      &:hover
+        border-color: base.$emphasis-border-hover
 
 .contact-us
   font-size: 1.2rem

--- a/app/helpers/home_emphasis_helper.rb
+++ b/app/helpers/home_emphasis_helper.rb
@@ -4,7 +4,7 @@ module HomeEmphasisHelper
     when Landing
       landing_path(item, **query_params)
     when LandingSubject
-      new_solicitation_path(landing_slug: "accueil", landing_subject_slug: item.slug, anchor: 'section-breadcrumbs', **query_params)
+      new_solicitation_path(landing_slug: "accueil", landing_subject_slug: item.slug, **query_params)
     end
   end
 end

--- a/app/views/landings/landings/_home_emphasis_item.html.erb
+++ b/app/views/landings/landings/_home_emphasis_item.html.erb
@@ -3,13 +3,11 @@
 <div class="fr-notice fr-notice--info emphasis block-link">
   <div class="fr-container">
     <div class="fr-notice__body">
-      <p>
-        <%= simple_format(emphasis_item.title, { class: "fr-notice__title" }, wrapper_tag: 'span') %>
-        <%= simple_format(emphasis_item.home_description, { class: "fr-notice__desc" }, wrapper_tag: 'span') %>
-      </p>
-      <p>
-        <%= link_to emphasis_item.home_link_text, path_to_emphasis_item(emphasis_item, **query_params), class: 'fr-notice__link' %>
-      </p>
+      <div>
+        <%= simple_format(emphasis_item.title, { class: "fr-notice__title" }) %>
+        <%= simple_format(emphasis_item.home_description, { class: "fr-notice__desc" }) %>
+      </div>
+      <%= link_to emphasis_item.home_link_text, path_to_emphasis_item(emphasis_item, **query_params), class: 'fr-notice__link' %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
followup #4677
| | |
|-|-|
|Avant|<img width="1306" height="145" alt="image" src="https://github.com/user-attachments/assets/19c15de3-c2a0-4d85-ab91-64a853fc1655" />|
|Après|<img width="1335" height="151" alt="image" src="https://github.com/user-attachments/assets/ca7cfd80-e732-4951-a496-6d3df30f4b41" />|
